### PR TITLE
Implemented REPLACE

### DIFF
--- a/memory/table.go
+++ b/memory/table.go
@@ -263,8 +263,8 @@ func (t *Table) Delete(ctx *sql.Context, row sql.Row) error {
 		return err
 	}
 
+	matches := false
 	for partitionIndex, partition := range t.partitions {
-		matches := false
 		for partitionRowIndex, partitionRow := range partition {
 			matches = true
 			for rIndex, val := range row {
@@ -281,6 +281,10 @@ func (t *Table) Delete(ctx *sql.Context, row sql.Row) error {
 		if matches {
 			break
 		}
+	}
+
+	if !matches {
+		return sql.ErrDeleteRowNotFound
 	}
 
 	return nil

--- a/sql/core.go
+++ b/sql/core.go
@@ -29,6 +29,9 @@ var (
 	// ErrInvalidChildrenNumber is returned when the WithChildren method of a
 	// node or expression is called with an invalid number of arguments.
 	ErrInvalidChildrenNumber = errors.NewKind("%T: invalid children number, got %d, expected %d")
+
+	// ErrDeleteRowNotFound
+	ErrDeleteRowNotFound = errors.NewKind("row was not found when attempting to delete").New()
 )
 
 // Nameable is something that has a name.
@@ -204,8 +207,14 @@ type Inserter interface {
 
 // Deleter allow rows to be deleted from them.
 type Deleter interface {
-	// Delete the given row.
+	// Delete the given row. Returns ErrDeleteRowNotFound if the row was not found.
 	Delete(*Context, Row) error
+}
+
+// Replacer allows rows to be replaced through a Delete (if applicable) then Insert.
+type Replacer interface {
+	Deleter
+	Inserter
 }
 
 // Database represents the database.

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -373,6 +373,11 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 		return nil, ErrUnsupportedSyntax.New(i)
 	}
 
+	isReplace := false
+	if i.Action == sqlparser.ReplaceStr {
+		isReplace = true
+	}
+
 	src, err := insertRowsToNode(ctx, i.Rows)
 	if err != nil {
 		return nil, err
@@ -381,6 +386,7 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 	return plan.NewInsertInto(
 		plan.NewUnresolvedTable(i.Table.Name.String(), i.Table.Qualifier.String()),
 		src,
+		isReplace,
 		columnsToStrings(i.Columns),
 	), nil
 }

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -252,6 +252,16 @@ var fixtures = map[string]sql.Node{
 			expression.NewLiteral("a", sql.Text),
 			expression.NewLiteral(int64(1), sql.Int64),
 		}}),
+		false,
+		[]string{"col1", "col2"},
+	),
+	`REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`: plan.NewInsertInto(
+		plan.NewUnresolvedTable("t1", ""),
+		plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("a", sql.Text),
+			expression.NewLiteral(int64(1), sql.Int64),
+		}}),
+		true,
 		[]string{"col1", "col2"},
 	),
 	`SHOW TABLES`:               plan.NewShowTables(sql.UnresolvedDatabase(""), false),


### PR DESCRIPTION
I decided to go with the `Delete` then `Insert` way instead of adding a `Replacer` interface. The insert-only functionality in the event of no primary key isn't what the "expected" behavior would be in my opinion, and since we don't have a way to check from this library, I think we should just do it this way instead. On the other side, if we have a `Replacer` interface, then we can't ensure that the implementer will properly choose if it will an Insert-only. I'd rather enforce a behavior that will be applicable and correct in the most obvious case, and it reduces the necessary code from implementers too since they won't need to duplicate any trigger functionality or anything.