### PR TITLE
Throw an error on CREATE VIEW statements, which were parsing as CREAT…

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -47,6 +47,7 @@ var (
 	unlockTablesRegex    = regexp.MustCompile(`^unlock\s+tables$`)
 	lockTablesRegex      = regexp.MustCompile(`^lock\s+tables\s`)
 	setRegex             = regexp.MustCompile(`^set\s+`)
+	createViewRegex      = regexp.MustCompile(`^create\s+view\s+`)
 )
 
 // These constants aren't exported from vitess for some reason. This could be removed if we changed this.
@@ -103,6 +104,9 @@ func Parse(ctx *sql.Context, query string) (sql.Node, error) {
 		return parseLockTables(ctx, s)
 	case setRegex.MatchString(lowerQuery):
 		s = fixSetQuery(s)
+	case createViewRegex.MatchString(lowerQuery):
+		// CREATE VIEW parses as a CREATE DDL statement with an empty table spec
+		return nil, ErrUnsupportedFeature.New("CREATE VIEW")
 	}
 
 	stmt, err := sqlparser.Parse(s)

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1296,6 +1296,7 @@ var fixturesErrors = map[string]*errors.Kind{
 	`SELECT INTERVAL 1 DAY + INTERVAL 1 DAY`:                  ErrUnsupportedSyntax,
 	`SELECT '2018-05-01' + (INTERVAL 1 DAY + INTERVAL 1 DAY)`: ErrUnsupportedSyntax,
 	`SELECT AVG(DISTINCT foo) FROM b`:                         ErrUnsupportedSyntax,
+	`CREATE VIEW view1 AS SELECT x FROM t1 WHERE x>0`:         ErrUnsupportedFeature,
 }
 
 func TestParseErrors(t *testing.T) {


### PR DESCRIPTION
…E TABLE with an empty table spec prior to this change.

Signed-off-by: Zach Musgrave <zach@liquidata.co>