### PR TITLE
Indexed joins

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -97,8 +97,8 @@ func NewDefault() *Engine {
 
 // Query executes a query.
 func (e *Engine) Query(
-	ctx *sql.Context,
-	query string,
+		ctx *sql.Context,
+		query string,
 ) (sql.Schema, sql.RowIter, error) {
 	var (
 		parsed, analyzed sql.Node

--- a/engine_test.go
+++ b/engine_test.go
@@ -1599,6 +1599,35 @@ var queries = []queryTest{
 		},
 	},
 	{
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i WHERE f IS NOT NULL ORDER BY 1",
+		[]sql.Row{
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+		},
+	},
+	{
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i WHERE f IS NOT NULL ORDER BY 2,3",
+		[]sql.Row{
+			{nil, nil, float64(3.0)},
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+		},
+	},
+	{
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i WHERE pk > 1 ORDER BY 1",
+		[]sql.Row{
+			{2, int64(2), float64(2.0)},
+			{3, nil, nil},
+		},
+	},
+	{
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i WHERE pk > 0 ORDER BY 2,3",
+		[]sql.Row{
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+		},
+	},
+	{
 		"SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0, 0, 0},

--- a/engine_test.go
+++ b/engine_test.go
@@ -1599,6 +1599,25 @@ var queries = []queryTest{
 		},
 	},
 	{
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i AND f IS NOT NULL ORDER BY 1", // NOT NULL clause in join condition is ignored
+		[]sql.Row{
+			{0, nil, nil},
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+			{3, nil, nil},
+		},
+	},
+	{
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i and pk > 0 ORDER BY 2,3", // > 0 clause in join condition is ignored
+		[]sql.Row{
+			{nil, nil, nil},
+			{nil, nil, float64(3.0)},
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+			{nil, int64(4), nil},
+		},
+	},
+	{
 		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i WHERE f IS NOT NULL ORDER BY 1",
 		[]sql.Row{
 			{1, int64(1), float64(1.0)},

--- a/engine_test.go
+++ b/engine_test.go
@@ -1563,13 +1563,13 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{1, 0, 1},
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk on pk=pk1 ORDER BY 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk ON pk=pk1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -1580,7 +1580,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i ORDER BY 1",
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i ORDER BY 1",
 		[]sql.Row{
 			{0, nil, nil},
 			{1, int64(1), float64(1.0)},
@@ -1589,7 +1589,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i ORDER BY 2,3",
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i ORDER BY 2,3",
 		[]sql.Row{
 			{nil, nil, nil},
 			{nil, nil, float64(3.0)},
@@ -1599,7 +1599,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i AND f IS NOT NULL ORDER BY 1", // NOT NULL clause in join condition is ignored
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i AND f IS NOT NULL ORDER BY 1", // NOT NULL clause in join condition is ignored
 		[]sql.Row{
 			{0, nil, nil},
 			{1, int64(1), float64(1.0)},
@@ -1608,7 +1608,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i and pk > 0 ORDER BY 2,3", // > 0 clause in join condition is ignored
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i and pk > 0 ORDER BY 2,3", // > 0 clause in join condition is ignored
 		[]sql.Row{
 			{nil, nil, nil},
 			{nil, nil, float64(3.0)},
@@ -1618,14 +1618,14 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i WHERE f IS NOT NULL ORDER BY 1",
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE f IS NOT NULL ORDER BY 1",
 		[]sql.Row{
 			{1, int64(1), float64(1.0)},
 			{2, int64(2), float64(2.0)},
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i WHERE f IS NOT NULL ORDER BY 2,3",
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i WHERE f IS NOT NULL ORDER BY 2,3",
 		[]sql.Row{
 			{nil, nil, float64(3.0)},
 			{1, int64(1), float64(1.0)},
@@ -1633,21 +1633,21 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i WHERE pk > 1 ORDER BY 1",
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE pk > 1 ORDER BY 1",
 		[]sql.Row{
 			{2, int64(2), float64(2.0)},
 			{3, nil, nil},
 		},
 	},
 	{
-		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i WHERE pk > 0 ORDER BY 2,3",
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i WHERE pk > 0 ORDER BY 2,3",
 		[]sql.Row{
 			{1, int64(1), float64(1.0)},
 			{2, int64(2), float64(2.0)},
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
+		"SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0, 0, 0},
 			{1, 0, 1, 10, 10},
@@ -1656,13 +1656,13 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2,one_pk.c1 AS foo,two_pk.c1 AS bar FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE one_pk.c1=10",
+		"SELECT pk,pk1,pk2,one_pk.c1 AS foo,two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE one_pk.c1=10",
 		[]sql.Row{
 			{1, 0, 1, 10, 10},
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on pk1-pk>0 AND pk2<1",
+		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON pk1-pk>0 AND pk2<1",
 		[]sql.Row{
 			{0, 1, 0},
 		},
@@ -2336,7 +2336,7 @@ func TestClearWarnings(t *testing.T) {
 	err = iter.Close()
 	require.NoError(err)
 
-	_, iter, err = e.Query(ctx, "-- some empty query AS a comment")
+	_, iter, err = e.Query(ctx, "-- some empty query as a comment")
 	require.NoError(err)
 	err = iter.Close()
 	require.NoError(err)
@@ -2604,7 +2604,7 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable (s,i) SELECT concat(m.s, o.s2), m.i FROM othertable o JOIN mytable m on m.i=o.i2",
+			"INSERT INTO mytable (s,i) SELECT concat(m.s, o.s2), m.i FROM othertable o JOIN mytable m ON m.i=o.i2",
 			[]sql.Row{{int64(3)}},
 			"SELECT * FROM mytable ORDER BY i,s",
 			[]sql.Row{
@@ -2689,16 +2689,16 @@ func TestInsertIntoErrors(t *testing.T) {
 			"INSERT INTO mytable (i, s) select * FROM othertable",
 		},
 		{
-			"column count mismatch IN select",
+			"column count mismatch in select",
 			"INSERT INTO mytable (i) select * FROM othertable",
 		},
 		{
-			"column count mismatch IN select",
+			"column count mismatch in select",
 			"INSERT INTO mytable select s FROM othertable",
 		},
 		{
-			"column count mismatch IN join select",
-			"INSERT INTO mytable (s,i) SELECT * FROM othertable o join mytable m on m.i=o.i2",
+			"column count mismatch in join select",
+			"INSERT INTO mytable (s,i) SELECT * FROM othertable o JOIN mytable m ON m.i=o.i2",
 		},
 	}
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -44,7 +44,7 @@ var queries = []queryTest{
 			{"third row", int64(3)}},
 	},
 	{
-		"SELECT s,i FROM (select i,s from mytable) mt;",
+		"SELECT s,i FROM (select i,s FROM mytable) mt;",
 		[]sql.Row{
 			{"first row", int64(1)},
 			{"second row", int64(2)},
@@ -67,7 +67,7 @@ var queries = []queryTest{
 		[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
 	},
 	{
-		"SELECT i FROM mytable where -i = -2;",
+		"SELECT i FROM mytable WHERE -i = -2;",
 		[]sql.Row{{int64(2)}},
 	},
 	{
@@ -87,19 +87,19 @@ var queries = []queryTest{
 		[]sql.Row{{int64(1)}, {int64(3)}},
 	},
 	{
-		"SELECT i FROM mytable WHERE i in (1, 3)",
+		"SELECT i FROM mytable WHERE i IN (1, 3)",
 		[]sql.Row{{int64(1)}, {int64(3)}},
 	},
 	{
-		"SELECT i FROM mytable WHERE i = 1 or i = 3",
+		"SELECT i FROM mytable WHERE i = 1 OR i = 3",
 		[]sql.Row{{int64(1)}, {int64(3)}},
 	},
 	{
-		"SELECT i FROM mytable WHERE i >= 2 order by 1",
+		"SELECT i FROM mytable WHERE i >= 2 ORDER BY 1",
 		[]sql.Row{{int64(2)}, {int64(3)}},
 	},
 	{
-		"SELECT i FROM mytable WHERE i <= 2 order by 1",
+		"SELECT i FROM mytable WHERE i <= 2 ORDER BY 1",
 		[]sql.Row{{int64(1)}, {int64(2)}},
 	},
 	{
@@ -111,7 +111,7 @@ var queries = []queryTest{
 		[]sql.Row{{int64(1)}},
 	},
 	{
-		"SELECT i FROM mytable WHERE i >= 2 or i = 1 order by 1",
+		"SELECT i FROM mytable WHERE i >= 2 OR i = 1 ORDER BY 1",
 		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
@@ -167,7 +167,7 @@ var queries = []queryTest{
 		nil,
 	},
 	{
-		"SELECT i FROM mytable WHERE not 'hello';",
+		"SELECT i FROM mytable WHERE NOT 'hello';",
 		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
@@ -265,7 +265,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT SUBSTRING_INDEX(mytable.s, "d", 1) as s FROM mytable INNER JOIN othertable ON (SUBSTRING_INDEX(mytable.s, "d", 1) = SUBSTRING_INDEX(othertable.s2, "d", 1)) GROUP BY 1 HAVING s = 'secon'`,
+		`SELECT SUBSTRING_INDEX(mytable.s, "d", 1) AS s FROM mytable INNER JOIN othertable ON (SUBSTRING_INDEX(mytable.s, "d", 1) = SUBSTRING_INDEX(othertable.s2, "d", 1)) GROUP BY 1 HAVING s = 'secon'`,
 		[]sql.Row{{"secon"}},
 	},
 	{
@@ -337,7 +337,7 @@ var queries = []queryTest{
 		[]sql.Row{{int64(3)}},
 	},
 	{
-		"SELECT substring(mytable.s, 1, 5) as s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
+		"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
 		[]sql.Row{
 			{"third"},
 			{"secon"},
@@ -345,11 +345,35 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 order by i",
+		"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
 		[]sql.Row{
 			{int64(1), int64(1), "third"},
 			{int64(2), int64(2), "second"},
 			{int64(3), int64(3), "first"},
+		},
+	},
+	{
+		"SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{"third", int64(1), int64(1)},
+			{"second", int64(2), int64(2)},
+			{ "first", int64(3), int64(3)},
+		},
+	},
+	{
+		"SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{int64(1), int64(1), "third"},
+			{int64(2), int64(2), "second"},
+			{int64(3), int64(3), "first"},
+		},
+	},
+	{
+		"SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{"third", int64(1), int64(1)},
+			{"second", int64(2), int64(2)},
+			{ "first", int64(3), int64(3)},
 		},
 	},
 	{
@@ -382,7 +406,7 @@ var queries = []queryTest{
 	},
 	{
 		"SELECT s FROM mytable INNER JOIN othertable " +
-				"ON substring(s2, 1, 2) != '' AND i = i2 order by 1",
+				"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
 		[]sql.Row{
 			{"first row"},
 			{"second row"},
@@ -390,7 +414,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) as cnt, fi FROM (
+		`SELECT COUNT(*) AS cnt, fi FROM (
 			SELECT tbl.s AS fi
 			FROM mytable tbl
 		) t
@@ -428,7 +452,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) as cnt, fi FROM (
+		`SELECT COUNT(*) AS cnt, fi FROM (
 			SELECT tbl.s AS fi
 			FROM mytable tbl
 		) t
@@ -440,7 +464,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) as cnt, s as fi FROM mytable GROUP BY fi`,
+		`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY fi`,
 		[]sql.Row{
 			{int64(1), "first row"},
 			{int64(1), "second row"},
@@ -448,7 +472,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) as cnt, s as fi FROM mytable GROUP BY 2`,
+		`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY 2`,
 		[]sql.Row{
 			{int64(1), "first row"},
 			{int64(1), "second row"},
@@ -569,7 +593,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT i as foo FROM mytable ORDER BY i DESC`,
+		`SELECT i AS foo FROM mytable ORDER BY i DESC`,
 		[]sql.Row{
 			{int64(3)},
 			{int64(2)},
@@ -577,7 +601,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) c, i as foo FROM mytable GROUP BY i ORDER BY i DESC`,
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY i DESC`,
 		[]sql.Row{
 			{int64(1), int64(3)},
 			{int64(1), int64(2)},
@@ -585,7 +609,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) c, i as foo FROM mytable GROUP BY 2 ORDER BY 2 DESC`,
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY 2 DESC`,
 		[]sql.Row{
 			{int64(1), int64(3)},
 			{int64(1), int64(2)},
@@ -593,7 +617,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) c, i as foo FROM mytable GROUP BY i ORDER BY foo DESC`,
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY foo DESC`,
 		[]sql.Row{
 			{int64(1), int64(3)},
 			{int64(1), int64(2)},
@@ -601,7 +625,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) c, i as foo FROM mytable GROUP BY 2 ORDER BY foo DESC`,
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY foo DESC`,
 		[]sql.Row{
 			{int64(1), int64(3)},
 			{int64(1), int64(2)},
@@ -609,7 +633,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT COUNT(*) c, i as i FROM mytable GROUP BY 2`,
+		`SELECT COUNT(*) c, i AS i FROM mytable GROUP BY 2`,
 		[]sql.Row{
 			{int64(1), int64(3)},
 			{int64(1), int64(2)},
@@ -617,7 +641,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT i as i FROM mytable GROUP BY 1`,
+		`SELECT i AS i FROM mytable GROUP BY 1`,
 		[]sql.Row{
 			{int64(3)},
 			{int64(2)},
@@ -711,7 +735,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		`SELECT SUBSTRING(s, -3, 3) as s FROM mytable WHERE s LIKE '%d row' GROUP BY 1`,
+		`SELECT SUBSTRING(s, -3, 3) AS s FROM mytable WHERE s LIKE '%d row' GROUP BY 1`,
 		[]sql.Row{
 			{"row"},
 		},
@@ -979,27 +1003,27 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT i FROM mytable where NULL > 10;",
+		"SELECT i FROM mytable WHERE NULL > 10;",
 		nil,
 	},
 	{
-		"SELECT i FROM mytable where NULL in (10);",
+		"SELECT i FROM mytable WHERE NULL IN (10);",
 		nil,
 	},
 	{
-		"SELECT i FROM mytable where NULL in (NULL, NULL);",
+		"SELECT i FROM mytable WHERE NULL IN (NULL, NULL);",
 		nil,
 	},
 	{
-		"SELECT i FROM mytable where NOT NULL NOT IN (NULL);",
+		"SELECT i FROM mytable WHERE NOT NULL NOT IN (NULL);",
 		nil,
 	},
 	{
-		"SELECT i FROM mytable where NOT (NULL) <> 10;",
+		"SELECT i FROM mytable WHERE NOT (NULL) <> 10;",
 		nil,
 	},
 	{
-		"SELECT i FROM mytable where NOT NULL <> NULL;",
+		"SELECT i FROM mytable WHERE NOT NULL <> NULL;",
 		nil,
 	},
 	{
@@ -1131,7 +1155,7 @@ var queries = []queryTest{
 		[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(2)}},
 	},
 	{
-		"SELECT substring(mytable.s, 1, 5) as s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
+		"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
 		[]sql.Row{{"secon"}},
 	},
 	{
@@ -1167,7 +1191,7 @@ var queries = []queryTest{
 		[]sql.Row{{nil}},
 	},
 	{
-		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) as date_col) t WHERE t.date_col > '0000-01-01 00:00:00'`,
+		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) AS date_col) t WHERE t.date_col > '0000-01-01 00:00:00'`,
 		[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
 	},
 	{
@@ -1409,11 +1433,11 @@ var queries = []queryTest{
 	{
 		"SELECT * FROM newlinetable WHERE s LIKE '%text%'",
 		[]sql.Row{
-			{int64(1), "\nthere is some text in here"},
-			{int64(2), "there is some\ntext in here"},
+			{int64(1), "\nthere is some text IN here"},
+			{int64(2), "there is some\ntext IN here"},
 			{int64(3), "there is some text\nin here"},
-			{int64(4), "there is some text in here\n"},
-			{int64(5), "there is some text in here"},
+			{int64(4), "there is some text IN here\n"},
+			{int64(5), "there is some text IN here"},
 		},
 	},
 	{
@@ -1453,7 +1477,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select pk,pk1,pk2 from one_pk, two_pk order by 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk, two_pk ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -1474,7 +1498,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select t1.c1,t2.c2 from one_pk t1, two_pk t2 where pk1=1 and pk2=1 order by 1,2",
+		"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 AND pk2=1 ORDER BY 1,2",
 		[]sql.Row{
 			{0, 30},
 			{10, 30},
@@ -1483,7 +1507,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select t1.c1,t2.c2 from one_pk t1, two_pk t2 where pk1=1 or pk2=1 order by 1,2",
+		"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 OR pk2=1 ORDER BY 1,2",
 		[]sql.Row{
 			{0, 10},
 			{0, 20},
@@ -1500,14 +1524,14 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select pk,pk2 from one_pk t1, two_pk t2 where pk=1 and pk2=1 order by 1,2",
+		"SELECT pk,pk2 FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2",
 		[]sql.Row{
 			{1, 1},
 			{1, 1},
 		},
 	},
 	{
-		"select pk,pk1,pk2 from one_pk,two_pk where pk=0 and pk1=0 or pk2=1 order by 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE pk=0 AND pk1=0 OR pk2=1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -1521,7 +1545,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select pk,pk1,pk2 from one_pk,two_pk where one_pk.c1=two_pk.c1 order by 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{1, 0, 1},
@@ -1530,7 +1554,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select one_pk.c5,pk1,pk2 from one_pk,two_pk where pk=pk1 order by 1,2,3",
+		"SELECT one_pk.c5,pk1,pk2 FROM one_pk,two_pk WHERE pk=pk1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -1539,13 +1563,24 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select pk,pk1,pk2 from one_pk join two_pk on one_pk.c1=two_pk.c1 where pk=1 order by 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{1, 0, 1},
 		},
 	},
 	{
-		"select pk,pk1,pk2,one_pk.c1 as foo, two_pk.c1 as bar from one_pk join two_pk on one_pk.c1=two_pk.c1 order by 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk on pk=pk1 ORDER BY 1,2,3",
+		[]sql.Row{
+			{0, 0, 0},
+			{0, 0, 1},
+			{1, 1, 0},
+			{1, 1, 1},
+			{2, nil, nil},
+			{3, nil, nil},
+		},
+	},
+	{
+		"SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0, 0, 0},
 			{1, 0, 1, 10, 10},
@@ -1554,19 +1589,19 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"select pk,pk1,pk2,one_pk.c1 as foo,two_pk.c1 as bar from one_pk join two_pk on one_pk.c1=two_pk.c1 where one_pk.c1=10",
+		"SELECT pk,pk1,pk2,one_pk.c1 AS foo,two_pk.c1 AS bar FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE one_pk.c1=10",
 		[]sql.Row{
 			{1, 0, 1, 10, 10},
 		},
 	},
 	{
-		"select pk,pk1,pk2 from one_pk join two_pk on pk1-pk>0 and pk2<1",
+		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on pk1-pk>0 AND pk2<1",
 		[]sql.Row{
 			{0, 1, 0},
 		},
 	},
 	{
-		"select pk,pk1,pk2 from one_pk join two_pk order by 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -1826,7 +1861,7 @@ var infoSchemaQueries = []queryTest {
 	},
 	{
 		`
-		SELECT COLUMN_NAME as COLUMN_NAME FROM information_schema.COLUMNS
+		SELECT COLUMN_NAME AS COLUMN_NAME FROM information_schema.COLUMNS
 		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME LIKE '%table'
 		GROUP BY 1
 		`,
@@ -1860,7 +1895,7 @@ var infoSchemaQueries = []queryTest {
 	},
 	{
 		`
-		SELECT COLUMN_NAME as COLUMN_NAME FROM information_schema.COLUMNS
+		SELECT COLUMN_NAME AS COLUMN_NAME FROM information_schema.COLUMNS
 		WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME LIKE '%table'
 		GROUP BY 1 HAVING SUBSTRING(COLUMN_NAME, 1, 1) = "s"
 		`,
@@ -2234,7 +2269,7 @@ func TestClearWarnings(t *testing.T) {
 	err = iter.Close()
 	require.NoError(err)
 
-	_, iter, err = e.Query(ctx, "-- some empty query as a comment")
+	_, iter, err = e.Query(ctx, "-- some empty query AS a comment")
 	require.NoError(err)
 	err = iter.Close()
 	require.NoError(err)
@@ -2329,7 +2364,7 @@ func TestInsertInto(t *testing.T) {
 		{
 			"INSERT INTO niltable (f) VALUES (10.0), (12.0);",
 			[]sql.Row{{int64(2)}},
-			"SELECT f FROM niltable WHERE f in (10.0, 12.0) order by f;",
+			"SELECT f FROM niltable WHERE f IN (10.0, 12.0) ORDER BY f;",
 			[]sql.Row{{10.0}, {12.0}},
 		},
 		{
@@ -2437,9 +2472,9 @@ func TestInsertInto(t *testing.T) {
 			[]sql.Row{{int64(999), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil}},
 		},
 		{
-			"INSERT INTO mytable SELECT * from mytable",
+			"INSERT INTO mytable SELECT * FROM mytable",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i",
+			"SELECT * FROM mytable ORDER BY i",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(1), "first row"},
@@ -2450,9 +2485,9 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable(i,s) SELECT * from mytable",
+			"INSERT INTO mytable(i,s) SELECT * FROM mytable",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i",
+			"SELECT * FROM mytable ORDER BY i",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(1), "first row"},
@@ -2463,9 +2498,9 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable (i,s) SELECT i+10, 'new' from mytable",
+			"INSERT INTO mytable (i,s) SELECT i+10, 'new' FROM mytable",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i",
+			"SELECT * FROM mytable ORDER BY i",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(2), "second row"},
@@ -2476,9 +2511,9 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable SELECT i2, s2 from othertable",
+			"INSERT INTO mytable SELECT i2, s2 FROM othertable",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i,s",
+			"SELECT * FROM mytable ORDER BY i,s",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(1), "third"},
@@ -2489,9 +2524,9 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable (s,i) SELECT * from othertable",
+			"INSERT INTO mytable (s,i) SELECT * FROM othertable",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i,s",
+			"SELECT * FROM mytable ORDER BY i,s",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(1), "third"},
@@ -2502,9 +2537,9 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable (s,i) SELECT concat(m.s, o.s2), m.i from othertable o join mytable m on m.i=o.i2",
+			"INSERT INTO mytable (s,i) SELECT concat(m.s, o.s2), m.i FROM othertable o JOIN mytable m on m.i=o.i2",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i,s",
+			"SELECT * FROM mytable ORDER BY i,s",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(1), "first rowthird"},
@@ -2515,9 +2550,9 @@ func TestInsertInto(t *testing.T) {
 			},
 		},
 		{
-			"INSERT INTO mytable (i,s) SELECT (i + 10.0) / 10.0 + 10, concat(s, ' new') from mytable",
+			"INSERT INTO mytable (i,s) SELECT (i + 10.0) / 10.0 + 10, concat(s, ' new') FROM mytable",
 			[]sql.Row{{int64(3)}},
-			"SELECT * FROM mytable order by i, s",
+			"SELECT * FROM mytable ORDER BY i, s",
 			[]sql.Row{
 				{int64(1), "first row"},
 				{int64(2), "second row"},
@@ -2584,19 +2619,19 @@ func TestInsertIntoErrors(t *testing.T) {
 		},
 		{
 			"incompatible types",
-			"INSERT INTO mytable (i, s) select * from othertable",
+			"INSERT INTO mytable (i, s) select * FROM othertable",
 		},
 		{
-			"column count mismatch in select",
-			"INSERT INTO mytable (i) select * from othertable",
+			"column count mismatch IN select",
+			"INSERT INTO mytable (i) select * FROM othertable",
 		},
 		{
-			"column count mismatch in select",
-			"INSERT INTO mytable select s from othertable",
+			"column count mismatch IN select",
+			"INSERT INTO mytable select s FROM othertable",
 		},
 		{
-			"column count mismatch in join select",
-			"INSERT INTO mytable (s,i) SELECT * from othertable o join mytable m on m.i=o.i2",
+			"column count mismatch IN join select",
+			"INSERT INTO mytable (s,i) SELECT * FROM othertable o join mytable m on m.i=o.i2",
 		},
 	}
 
@@ -3288,7 +3323,7 @@ func TestAddColumn(t *testing.T) {
 	}, tbl.Schema())
 
 	testQuery(t, e,
-		"SELECT * from mytable order by i",
+		"SELECT * FROM mytable ORDER BY i",
 		[]sql.Row{
 			sql.NewRow(int64(1), "first row", int32(42)),
 			sql.NewRow(int64(2), "second row", int32(42)),
@@ -3312,7 +3347,7 @@ func TestAddColumn(t *testing.T) {
 	}, tbl.Schema())
 
 	testQuery(t, e,
-		"SELECT * from mytable order by i",
+		"SELECT * FROM mytable ORDER BY i",
 		[]sql.Row{
 			sql.NewRow(int64(1), nil, "first row", int32(42)),
 			sql.NewRow(int64(2), nil, "second row", int32(42)),
@@ -3337,7 +3372,7 @@ func TestAddColumn(t *testing.T) {
 	}, tbl.Schema())
 
 	testQuery(t, e,
-		"SELECT * from mytable order by i",
+		"SELECT * FROM mytable ORDER BY i",
 		[]sql.Row{
 			sql.NewRow("yay", int64(1), nil, "first row", int32(42)),
 			sql.NewRow("yay", int64(2), nil, "second row", int32(42)),
@@ -3847,11 +3882,11 @@ func allTestTables(t *testing.T, numPartitions int) map[string]*memory.Table {
 
 	insertRows(
 		t, tables["newlinetable"],
-		sql.NewRow(int64(1), "\nthere is some text in here"),
-		sql.NewRow(int64(2), "there is some\ntext in here"),
+		sql.NewRow(int64(1), "\nthere is some text IN here"),
+		sql.NewRow(int64(2), "there is some\ntext IN here"),
 		sql.NewRow(int64(3), "there is some text\nin here"),
-		sql.NewRow(int64(4), "there is some text in here\n"),
-		sql.NewRow(int64(5), "there is some text in here"),
+		sql.NewRow(int64(4), "there is some text IN here\n"),
+		sql.NewRow(int64(5), "there is some text IN here"),
 	)
 
 	tables["typestable"] = memory.NewPartitionedTable("typestable", sql.Schema{
@@ -4151,7 +4186,7 @@ func TestNestedAliases(t *testing.T) {
 	require := require.New(t)
 
 	_, _, err := newEngine(t).Query(newCtx(), `
-	SELECT SUBSTRING(s, 1, 10) AS sub_s, SUBSTRING(sub_s, 2, 3) as sub_sub_s
+	SELECT SUBSTRING(s, 1, 10) AS sub_s, SUBSTRING(sub_s, 2, 3) AS sub_sub_s
 	FROM mytable`)
 	require.Error(err)
 	require.True(analyzer.ErrMisusedAlias.Is(err))
@@ -4214,7 +4249,7 @@ func TestDescribeNoPruneColumns(t *testing.T) {
 	require := require.New(t)
 	ctx := newCtx()
 	e := newEngine(t)
-	query := `DESCRIBE FORMAT=TREE SELECT SUBSTRING(s, 1, 1) as foo, s, i FROM mytable WHERE foo = 'f'`
+	query := `DESCRIBE FORMAT=TREE SELECT SUBSTRING(s, 1, 1) AS foo, s, i FROM mytable WHERE foo = 'f'`
 	parsed, err := parse.Parse(ctx, query)
 	require.NoError(err)
 	result, err := e.Analyzer.Analyze(ctx, parsed)

--- a/engine_test.go
+++ b/engine_test.go
@@ -32,1553 +32,1553 @@ type queryTest struct {
 }
 
 var queries = []queryTest{
-	// {
-	// 	"SELECT i FROM mytable;",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT s,i FROM mytable;",
-	// 	[]sql.Row{
-	// 		{"first row", int64(1)},
-	// 		{"second row", int64(2)},
-	// 		{"third row", int64(3)}},
-	// },
-	// {
-	// 	"SELECT s,i FROM (select i,s FROM mytable) mt;",
-	// 	[]sql.Row{
-	// 		{"first row", int64(1)},
-	// 		{"second row", int64(2)},
-	// 		{"third row", int64(3)}},
-	// },
-	// {
-	// 	"SELECT i + 1 FROM mytable;",
-	// 	[]sql.Row{{int64(2)}, {int64(3)}, {int64(4)}},
-	// },
-	// {
-	// 	"SELECT -i FROM mytable;",
-	// 	[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
-	// },
-	// {
-	// 	"SELECT +i FROM mytable;",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT + - i FROM mytable;",
-	// 	[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE -i = -2;",
-	// 	[]sql.Row{{int64(2)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i = 2;",
-	// 	[]sql.Row{{int64(2)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i > 2;",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i < 2;",
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i <> 2;",
-	// 	[]sql.Row{{int64(1)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i IN (1, 3)",
-	// 	[]sql.Row{{int64(1)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i = 1 OR i = 3",
-	// 	[]sql.Row{{int64(1)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i >= 2 ORDER BY 1",
-	// 	[]sql.Row{{int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i <= 2 ORDER BY 1",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i > 2",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i < 2",
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i >= 2 OR i = 1 ORDER BY 1",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT f32 FROM floattable WHERE f64 = 2.0;",
-	// 	[]sql.Row{{float32(2.0)}},
-	// },
-	// {
-	// 	"SELECT f32 FROM floattable WHERE f64 < 2.0;",
-	// 	[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}},
-	// },
-	// {
-	// 	"SELECT f32 FROM floattable WHERE f64 > 2.0;",
-	// 	[]sql.Row{{float32(2.5)}},
-	// },
-	// {
-	// 	"SELECT f32 FROM floattable WHERE f64 <> 2.0;",
-	// 	[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}, {float32(2.5)}},
-	// },
-	// {
-	// 	"SELECT f64 FROM floattable WHERE f32 = 2.0;",
-	// 	[]sql.Row{{float64(2.0)}},
-	// },
-	// {
-	// 	"SELECT f64 FROM floattable WHERE f32 = -1.5;",
-	// 	[]sql.Row{{float64(-1.5)}},
-	// },
-	// {
-	// 	"SELECT f64 FROM floattable WHERE -f32 = -2.0;",
-	// 	[]sql.Row{{float64(2.0)}},
-	// },
-	// {
-	// 	"SELECT f64 FROM floattable WHERE f32 < 2.0;",
-	// 	[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}},
-	// },
-	// {
-	// 	"SELECT f64 FROM floattable WHERE f32 > 2.0;",
-	// 	[]sql.Row{{float64(2.5)}},
-	// },
-	// {
-	// 	"SELECT f64 FROM floattable WHERE f32 <> 2.0;",
-	// 	[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}, {float64(2.5)}},
-	// },
-	// {
-	// 	"SELECT f32 FROM floattable ORDER BY f64;",
-	// 	[]sql.Row{{float32(-1.5)}, {float32(-1.0)}, {float32(1.0)}, {float32(1.5)}, {float32(2.0)}, {float32(2.5)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable ORDER BY i DESC;",
-	// 	[]sql.Row{{int64(3)}, {int64(2)}, {int64(1)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE 'hello';",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NOT 'hello';",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC;",
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable ORDER BY i LIMIT 1 OFFSET 1;",
-	// 	[]sql.Row{{int64(2)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable ORDER BY i LIMIT 1,1;",
-	// 	[]sql.Row{{int64(2)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable ORDER BY i LIMIT 3,1;",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable ORDER BY i LIMIT 2,100;",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE b IS NULL",
-	// 	[]sql.Row{{int64(2)}, {nil}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE b IS NOT NULL",
-	// 	[]sql.Row{{int64(1)}, {nil}, {int64(4)}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE b",
-	// 	[]sql.Row{{int64(1)}, {int64(4)}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE NOT b",
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE b IS TRUE",
-	// 	[]sql.Row{{int64(1)}, {int64(4)}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE b IS NOT TRUE",
-	// 	[]sql.Row{{int64(2)}, {nil}, {nil}},
-	// },
-	// {
-	// 	"SELECT f FROM niltable WHERE b IS FALSE",
-	// 	[]sql.Row{{3.0}},
-	// },
-	// {
-	// 	"SELECT i FROM niltable WHERE b IS NOT FALSE",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(4)}, {nil}},
-	// },
-	// {
-	// 	"SELECT COUNT(*) FROM mytable;",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT COUNT(*) FROM mytable LIMIT 1;",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT COUNT(*) AS c FROM mytable;",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT substring(s, 2, 3) FROM mytable",
-	// 	[]sql.Row{{"irs"}, {"eco"}, {"hir"}},
-	// },
-	// {
-	// 	`SELECT substring("foo", 2, 2)`,
-	// 	[]sql.Row{{"oo"}},
-	// },
-	// {
-	// 	`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', 2)`,
-	// 	[]sql.Row{
-	// 		{"a.b"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', -2)`,
-	// 	[]sql.Row{
-	// 		{"e.f"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT SUBSTRING_INDEX(SUBSTRING_INDEX('source{d}', '{d}', 1), 'r', -1)`,
-	// 	[]sql.Row{
-	// 		{"ce"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT SUBSTRING_INDEX(mytable.s, "d", 1) AS s FROM mytable INNER JOIN othertable ON (SUBSTRING_INDEX(mytable.s, "d", 1) = SUBSTRING_INDEX(othertable.s2, "d", 1)) GROUP BY 1 HAVING s = 'secon'`,
-	// 	[]sql.Row{{"secon"}},
-	// },
-	// {
-	// 	"SELECT YEAR('2007-12-11') FROM mytable",
-	// 	[]sql.Row{{int32(2007)}, {int32(2007)}, {int32(2007)}},
-	// },
-	// {
-	// 	"SELECT MONTH('2007-12-11') FROM mytable",
-	// 	[]sql.Row{{int32(12)}, {int32(12)}, {int32(12)}},
-	// },
-	// {
-	// 	"SELECT DAY('2007-12-11') FROM mytable",
-	// 	[]sql.Row{{int32(11)}, {int32(11)}, {int32(11)}},
-	// },
-	// {
-	// 	"SELECT HOUR('2007-12-11 20:21:22') FROM mytable",
-	// 	[]sql.Row{{int32(20)}, {int32(20)}, {int32(20)}},
-	// },
-	// {
-	// 	"SELECT MINUTE('2007-12-11 20:21:22') FROM mytable",
-	// 	[]sql.Row{{int32(21)}, {int32(21)}, {int32(21)}},
-	// },
-	// {
-	// 	"SELECT SECOND('2007-12-11 20:21:22') FROM mytable",
-	// 	[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
-	// },
-	// {
-	// 	"SELECT DAYOFYEAR('2007-12-11 20:21:22') FROM mytable",
-	// 	[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
-	// },
-	// {
-	// 	"SELECT SECOND('2007-12-11T20:21:22Z') FROM mytable",
-	// 	[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
-	// },
-	// {
-	// 	"SELECT DAYOFYEAR('2007-12-11') FROM mytable",
-	// 	[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
-	// },
-	// {
-	// 	"SELECT DAYOFYEAR('20071211') FROM mytable",
-	// 	[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
-	// },
-	// {
-	// 	"SELECT YEARWEEK('0000-01-01')",
-	// 	[]sql.Row{{int32(1)}},
-	// },
-	// {
-	// 	"SELECT YEARWEEK('9999-12-31')",
-	// 	[]sql.Row{{int32(999952)}},
-	// },
-	// {
-	// 	"SELECT YEARWEEK('2008-02-20', 1)",
-	// 	[]sql.Row{{int32(200808)}},
-	// },
-	// {
-	// 	"SELECT YEARWEEK('1987-01-01')",
-	// 	[]sql.Row{{int32(198652)}},
-	// },
-	// {
-	// 	"SELECT YEARWEEK('1987-01-01', 20), YEARWEEK('1987-01-01', 1), YEARWEEK('1987-01-01', 2), YEARWEEK('1987-01-01', 3), YEARWEEK('1987-01-01', 4), YEARWEEK('1987-01-01', 5), YEARWEEK('1987-01-01', 6), YEARWEEK('1987-01-01', 7)",
-	// 	[]sql.Row{{int32(198653), int32(198701), int32(198652), int32(198701), int32(198653), int32(198652), int32(198653), int32(198652)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i BETWEEN 1 AND 2",
-	// 	[]sql.Row{{int64(1)}, {int64(2)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE i NOT BETWEEN 1 AND 2",
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
-	// 	[]sql.Row{
-	// 		{"third"},
-	// 		{"secon"},
-	// 		{"first"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
-	// 	[]sql.Row{
-	// 		{int64(1), int64(1), "third"},
-	// 		{int64(2), int64(2), "second"},
-	// 		{int64(3), int64(3), "first"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
-	// 	[]sql.Row{
-	// 		{"third", int64(1), int64(1)},
-	// 		{"second", int64(2), int64(2)},
-	// 		{ "first", int64(3), int64(3)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
-	// 	[]sql.Row{
-	// 		{int64(1), int64(1), "third"},
-	// 		{int64(2), int64(2), "second"},
-	// 		{int64(3), int64(3), "first"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
-	// 	[]sql.Row{
-	// 		{"third", int64(1), int64(1)},
-	// 		{"second", int64(2), int64(2)},
-	// 		{ "first", int64(3), int64(3)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT substring(s2, 1), substring(s2, 2), substring(s2, 3) FROM othertable ORDER BY i2",
-	// 	[]sql.Row{
-	// 		{"third", "hird", "ird"},
-	// 		{"second", "econd", "cond"},
-	// 		{"first", "irst", "rst"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT substring("first", 1), substring("second", 2), substring("third", 3)`,
-	// 	[]sql.Row{
-	// 		{"first", "econd", "ird"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT substring(s2, -1), substring(s2, -2), substring(s2, -3) FROM othertable ORDER BY i2",
-	// 	[]sql.Row{
-	// 		{"d", "rd", "ird"},
-	// 		{"d", "nd", "ond"},
-	// 		{"t", "st", "rst"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT substring("first", -1), substring("second", -2), substring("third", -3)`,
-	// 	[]sql.Row{
-	// 		{"t", "nd", "ird"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s FROM mytable INNER JOIN othertable " +
-	// 			"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
-	// 	[]sql.Row{
-	// 		{"first row"},
-	// 		{"second row"},
-	// 		{"third row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) AS cnt, fi FROM (
-	// 		SELECT tbl.s AS fi
-	// 		FROM mytable tbl
-	// 	) t
-	// 	GROUP BY fi`,
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 		{int64(1), "second row"},
-	// 		{int64(1), "third row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT fi, COUNT(*) FROM (
-	// 		SELECT tbl.s AS fi
-	// 		FROM mytable tbl
-	// 	) t
-	// 	GROUP BY fi
-	// 	ORDER BY COUNT(*) ASC`,
-	// 	[]sql.Row{
-	// 		{"first row", int64(1)},
-	// 		{"second row", int64(1)},
-	// 		{"third row", int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*), fi  FROM (
-	// 		SELECT tbl.s AS fi
-	// 		FROM mytable tbl
-	// 	) t
-	// 	GROUP BY fi
-	// 	ORDER BY COUNT(*) ASC`,
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 		{int64(1), "second row"},
-	// 		{int64(1), "third row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) AS cnt, fi FROM (
-	// 		SELECT tbl.s AS fi
-	// 		FROM mytable tbl
-	// 	) t
-	// 	GROUP BY 2`,
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 		{int64(1), "second row"},
-	// 		{int64(1), "third row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY fi`,
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 		{int64(1), "second row"},
-	// 		{int64(1), "third row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY 2`,
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 		{int64(1), "second row"},
-	// 		{int64(1), "third row"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT CAST(-3 AS UNSIGNED) FROM mytable",
-	// 	[]sql.Row{
-	// 		{uint64(18446744073709551613)},
-	// 		{uint64(18446744073709551613)},
-	// 		{uint64(18446744073709551613)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT CONVERT(-3, UNSIGNED) FROM mytable",
-	// 	[]sql.Row{
-	// 		{uint64(18446744073709551613)},
-	// 		{uint64(18446744073709551613)},
-	// 		{uint64(18446744073709551613)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT '3' > 2 FROM tabletest",
-	// 	[]sql.Row{
-	// 		{true},
-	// 		{true},
-	// 		{true},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s > 2 FROM tabletest",
-	// 	[]sql.Row{
-	// 		{false},
-	// 		{false},
-	// 		{false},
-	// 	},
-	// },
-	// {
-	// 	"SELECT * FROM tabletest WHERE s > 0",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT * FROM tabletest WHERE s = 0",
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 		{int64(2), "second row"},
-	// 		{int64(3), "third row"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT * FROM tabletest WHERE s = 'first row'",
-	// 	[]sql.Row{
-	// 		{int64(1), "first row"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s FROM mytable WHERE i IN (1, 2, 5)",
-	// 	[]sql.Row{
-	// 		{"first row"},
-	// 		{"second row"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s FROM mytable WHERE i NOT IN (1, 2, 5)",
-	// 	[]sql.Row{
-	// 		{"third row"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT 1 + 2",
-	// 	[]sql.Row{
-	// 		{int64(3)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT i AS foo FROM mytable WHERE foo NOT IN (1, 2, 5)`,
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	`SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
-	// 	[]sql.Row{
-	// 		{int64(1), "first row", int64(1), "first row", "third", int64(1)},
-	// 		{int64(1), "first row", int64(2), "second row", "second", int64(2)},
-	// 		{int64(1), "first row", int64(3), "third row", "first", int64(3)},
-	// 		{int64(2), "second row", int64(1), "first row", "third", int64(1)},
-	// 		{int64(2), "second row", int64(2), "second row", "second", int64(2)},
-	// 		{int64(2), "second row", int64(3), "third row", "first", int64(3)},
-	// 		{int64(3), "third row", int64(1), "first row", "third", int64(1)},
-	// 		{int64(3), "third row", int64(2), "second row", "second", int64(2)},
-	// 		{int64(3), "third row", int64(3), "third row", "first", int64(3)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT split(s," ") FROM mytable`,
-	// 	[]sql.Row{
-	// 		sql.NewRow([]interface{}{"first", "row"}),
-	// 		sql.NewRow([]interface{}{"second", "row"}),
-	// 		sql.NewRow([]interface{}{"third", "row"}),
-	// 	},
-	// },
-	// {
-	// 	`SELECT split(s,"s") FROM mytable`,
-	// 	[]sql.Row{
-	// 		sql.NewRow([]interface{}{"fir", "t row"}),
-	// 		sql.NewRow([]interface{}{"", "econd row"}),
-	// 		sql.NewRow([]interface{}{"third row"}),
-	// 	},
-	// },
-	// {
-	// 	`SELECT SUM(i) FROM mytable`,
-	// 	[]sql.Row{{float64(6)}},
-	// },
-	// {
-	// 	`SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2`,
-	// 	[]sql.Row{
-	// 		{int64(3), "third row", "first", int64(3)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT i AS foo FROM mytable ORDER BY i DESC`,
-	// 	[]sql.Row{
-	// 		{int64(3)},
-	// 		{int64(2)},
-	// 		{int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY i DESC`,
-	// 	[]sql.Row{
-	// 		{int64(1), int64(3)},
-	// 		{int64(1), int64(2)},
-	// 		{int64(1), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY 2 DESC`,
-	// 	[]sql.Row{
-	// 		{int64(1), int64(3)},
-	// 		{int64(1), int64(2)},
-	// 		{int64(1), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY foo DESC`,
-	// 	[]sql.Row{
-	// 		{int64(1), int64(3)},
-	// 		{int64(1), int64(2)},
-	// 		{int64(1), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY foo DESC`,
-	// 	[]sql.Row{
-	// 		{int64(1), int64(3)},
-	// 		{int64(1), int64(2)},
-	// 		{int64(1), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COUNT(*) c, i AS i FROM mytable GROUP BY 2`,
-	// 	[]sql.Row{
-	// 		{int64(1), int64(3)},
-	// 		{int64(1), int64(2)},
-	// 		{int64(1), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT i AS i FROM mytable GROUP BY 1`,
-	// 	[]sql.Row{
-	// 		{int64(3)},
-	// 		{int64(2)},
-	// 		{int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT CONCAT("a", "b", "c")`,
-	// 	[]sql.Row{
-	// 		{string("abc")},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COALESCE(NULL, NULL, NULL, 'example', NULL, 1234567890)`,
-	// 	[]sql.Row{
-	// 		{string("example")},
-	// 	},
-	// },
-	// {
-	// 	`SELECT COALESCE(NULL, NULL, NULL, COALESCE(NULL, 1234567890))`,
-	// 	[]sql.Row{
-	// 		{int32(1234567890)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT concat(s, i) FROM mytable",
-	// 	[]sql.Row{
-	// 		{string("first row1")},
-	// 		{string("second row2")},
-	// 		{string("third row3")},
-	// 	},
-	// },
-	// {
-	// 	"SELECT version()",
-	// 	[]sql.Row{
-	// 		{string("8.0.11")},
-	// 	},
-	// },
-	// {
-	// 	"SELECT * FROM mytable WHERE 1 > 5",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT SUM(i) + 1, i FROM mytable GROUP BY i ORDER BY i",
-	// 	[]sql.Row{
-	// 		{float64(2), int64(1)},
-	// 		{float64(3), int64(2)},
-	// 		{float64(4), int64(3)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT SUM(i), i FROM mytable GROUP BY i ORDER BY 1+SUM(i) ASC",
-	// 	[]sql.Row{
-	// 		{float64(1), int64(1)},
-	// 		{float64(2), int64(2)},
-	// 		{float64(3), int64(3)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i, SUM(i) FROM mytable GROUP BY i ORDER BY SUM(i) DESC",
-	// 	[]sql.Row{
-	// 		{int64(3), float64(3)},
-	// 		{int64(2), float64(2)},
-	// 		{int64(1), float64(1)},
-	// 	},
-	// },
-	// {
-	// 	`/*!40101 SET NAMES utf8 */`,
-	// 	nil,
-	// },
-	// {
-	// 	`SHOW DATABASES`,
-	// 	[]sql.Row{{"mydb"}, {"foo"}},
-	// },
-	// {
-	// 	`SHOW SCHEMAS`,
-	// 	[]sql.Row{{"mydb"}, {"foo"}},
-	// },
-	// {
-	// 	`SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA`,
-	// 	[]sql.Row{
-	// 		{"mydb", "utf8mb4", "utf8_bin"},
-	// 		{"foo", "utf8mb4", "utf8_bin"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT s FROM mytable WHERE s LIKE '%d row'`,
-	// 	[]sql.Row{
-	// 		{"second row"},
-	// 		{"third row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT SUBSTRING(s, -3, 3) AS s FROM mytable WHERE s LIKE '%d row' GROUP BY 1`,
-	// 	[]sql.Row{
-	// 		{"row"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT s FROM mytable WHERE s NOT LIKE '%d row'`,
-	// 	[]sql.Row{
-	// 		{"first row"},
-	// 	},
-	// },
-	// {
-	// 	`SHOW COLUMNS FROM mytable`,
-	// 	[]sql.Row{
-	// 		{"i", "BIGINT", "NO", "", "", ""},
-	// 		{"s", "TEXT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`DESCRIBE mytable`,
-	// 	[]sql.Row{
-	// 		{"i", "BIGINT", "NO", "", "", ""},
-	// 		{"s", "TEXT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`DESC mytable`,
-	// 	[]sql.Row{
-	// 		{"i", "BIGINT", "NO", "", "", ""},
-	// 		{"s", "TEXT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`SHOW COLUMNS FROM one_pk`,
-	// 	[]sql.Row{
-	// 		{"pk", "TINYINT", "NO", "PRI", "", ""},
-	// 		{"c1", "TINYINT", "NO", "", "", ""},
-	// 		{"c2", "TINYINT", "NO", "", "", ""},
-	// 		{"c3", "TINYINT", "NO", "", "", ""},
-	// 		{"c4", "TINYINT", "NO", "", "", ""},
-	// 		{"c5", "TINYINT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`DESCRIBE one_pk`,
-	// 	[]sql.Row{
-	// 		{"pk", "TINYINT", "NO", "PRI", "", ""},
-	// 		{"c1", "TINYINT", "NO", "", "", ""},
-	// 		{"c2", "TINYINT", "NO", "", "", ""},
-	// 		{"c3", "TINYINT", "NO", "", "", ""},
-	// 		{"c4", "TINYINT", "NO", "", "", ""},
-	// 		{"c5", "TINYINT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`DESC one_pk`,
-	// 	[]sql.Row{
-	// 		{"pk", "TINYINT", "NO", "PRI", "", ""},
-	// 		{"c1", "TINYINT", "NO", "", "", ""},
-	// 		{"c2", "TINYINT", "NO", "", "", ""},
-	// 		{"c3", "TINYINT", "NO", "", "", ""},
-	// 		{"c4", "TINYINT", "NO", "", "", ""},
-	// 		{"c5", "TINYINT", "NO", "", "", ""},
-	// 	},
-	// },
-	//
-	// {
-	// 	`SHOW COLUMNS FROM mytable WHERE Field = 'i'`,
-	// 	[]sql.Row{
-	// 		{"i", "BIGINT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`SHOW COLUMNS FROM mytable LIKE 'i'`,
-	// 	[]sql.Row{
-	// 		{"i", "BIGINT", "NO", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`SHOW FULL COLUMNS FROM mytable`,
-	// 	[]sql.Row{
-	// 		{"i", "BIGINT", nil, "NO", "", "", "", "", ""},
-	// 		{"s", "TEXT", "utf8_bin", "NO", "", "", "", "", ""},
-	// 	},
-	// },
-	// {
-	// 	`SHOW FULL COLUMNS FROM one_pk`,
-	// 	[]sql.Row{
-	// 		{"pk", "TINYINT", nil, "NO", "PRI", "", "", "", ""},
-	// 		{"c1", "TINYINT", nil, "NO", "", "", "", "", ""},
-	// 		{"c2", "TINYINT", nil, "NO", "", "", "", "", ""},
-	// 		{"c3", "TINYINT", nil, "NO", "", "", "", "", ""},
-	// 		{"c4", "TINYINT", nil, "NO", "", "", "", "", ""},
-	// 		{"c5", "TINYINT", nil, "NO", "", "", "", "", "column 5"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT * FROM foo.other_table`,
-	// 	[]sql.Row{
-	// 		{"a", int32(4)},
-	// 		{"b", int32(2)},
-	// 		{"c", int32(0)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT AVG(23.222000)`,
-	// 	[]sql.Row{
-	// 		{float64(23.222)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT DATABASE()`,
-	// 	[]sql.Row{
-	// 		{"mydb"},
-	// 	},
-	// },
-	// {
-	// 	`SHOW VARIABLES`,
-	// 	[]sql.Row{
-	// 		{"auto_increment_increment", int64(1)},
-	// 		{"time_zone", time.Local.String()},
-	// 		{"system_time_zone", time.Local.String()},
-	// 		{"max_allowed_packet", math.MaxInt32},
-	// 		{"sql_mode", ""},
-	// 		{"gtid_mode", int32(0)},
-	// 		{"collation_database", "utf8_bin"},
-	// 		{"ndbinfo_version", ""},
-	// 		{"sql_select_limit", math.MaxInt32},
-	// 		{"transaction_isolation", "READ UNCOMMITTED"},
-	// 		{"version", ""},
-	// 		{"version_comment", ""},
-	// 	},
-	// },
-	// {
-	// 	`SHOW VARIABLES LIKE 'gtid_mode`,
-	// 	[]sql.Row{
-	// 		{"gtid_mode", int32(0)},
-	// 	},
-	// },
-	// {
-	// 	`SHOW VARIABLES LIKE 'gtid%`,
-	// 	[]sql.Row{
-	// 		{"gtid_mode", int32(0)},
-	// 	},
-	// },
-	// {
-	// 	`SHOW GLOBAL VARIABLES LIKE '%mode`,
-	// 	[]sql.Row{
-	// 		{"sql_mode", ""},
-	// 		{"gtid_mode", int32(0)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT JSON_EXTRACT("foo", "$")`,
-	// 	[]sql.Row{{"foo"}},
-	// },
-	// {
-	// 	`SELECT JSON_UNQUOTE('"foo"')`,
-	// 	[]sql.Row{{"foo"}},
-	// },
-	// {
-	// 	`SELECT JSON_UNQUOTE('[1, 2, 3]')`,
-	// 	[]sql.Row{{"[1, 2, 3]"}},
-	// },
-	// {
-	// 	`SELECT JSON_UNQUOTE('"\\t\\u0032"')`,
-	// 	[]sql.Row{{"\t2"}},
-	// },
-	// {
-	// 	`SELECT JSON_UNQUOTE('"\t\\u0032"')`,
-	// 	[]sql.Row{{"\t2"}},
-	// },
-	// {
-	// 	`SELECT CONNECTION_ID()`,
-	// 	[]sql.Row{{uint32(1)}},
-	// },
-	// {
-	// 	`SHOW CREATE DATABASE mydb`,
-	// 	[]sql.Row{{
-	// 		"mydb",
-	// 		"CREATE DATABASE `mydb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */",
-	// 	}},
-	// },
-	// {
-	// 	`SELECT -1`,
-	// 	[]sql.Row{{int8(-1)}},
-	// },
-	// {
-	// 	`
-	// 	SHOW WARNINGS
-	// 	`,
-	// 	nil,
-	// },
-	// {
-	// 	`SHOW WARNINGS LIMIT 0`,
-	// 	nil,
-	// },
-	// {
-	// 	`SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
-	// 	nil,
-	// },
-	// {
-	// 	`SELECT NULL`,
-	// 	[]sql.Row{
-	// 		{nil},
-	// 	},
-	// },
-	// {
-	// 	`SELECT nullif('abc', NULL)`,
-	// 	[]sql.Row{
-	// 		{"abc"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT nullif(NULL, NULL)`,
-	// 	[]sql.Row{
-	// 		{sql.Null},
-	// 	},
-	// },
-	// {
-	// 	`SELECT nullif(NULL, 123)`,
-	// 	[]sql.Row{
-	// 		{nil},
-	// 	},
-	// },
-	// {
-	// 	`SELECT nullif(123, 123)`,
-	// 	[]sql.Row{
-	// 		{sql.Null},
-	// 	},
-	// },
-	// {
-	// 	`SELECT nullif(123, 321)`,
-	// 	[]sql.Row{
-	// 		{int8(123)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT ifnull(123, NULL)`,
-	// 	[]sql.Row{
-	// 		{int8(123)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT ifnull(NULL, NULL)`,
-	// 	[]sql.Row{
-	// 		{nil},
-	// 	},
-	// },
-	// {
-	// 	`SELECT ifnull(NULL, 123)`,
-	// 	[]sql.Row{
-	// 		{int8(123)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT ifnull(123, 123)`,
-	// 	[]sql.Row{
-	// 		{int8(123)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT ifnull(123, 321)`,
-	// 	[]sql.Row{
-	// 		{int8(123)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NULL > 10;",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NULL IN (10);",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NULL IN (NULL, NULL);",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NOT NULL NOT IN (NULL);",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NOT (NULL) <> 10;",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NOT NULL <> NULL;",
-	// 	nil,
-	// },
-	// {
-	// 	`SELECT round(15728640/1024/1024)`,
-	// 	[]sql.Row{
-	// 		{int64(15)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT round(15, 1)`,
-	// 	[]sql.Row{
-	// 		{int8(15)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'other' END FROM mytable`,
-	// 	[]sql.Row{
-	// 		{"one"},
-	// 		{"two"},
-	// 		{"other"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT CASE WHEN i > 2 THEN 'more than two' WHEN i < 2 THEN 'less than two' ELSE 'two' END FROM mytable`,
-	// 	[]sql.Row{
-	// 		{"less than two"},
-	// 		{"two"},
-	// 		{"more than two"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' END FROM mytable`,
-	// 	[]sql.Row{
-	// 		{"one"},
-	// 		{"two"},
-	// 		{nil},
-	// 	},
-	// },
-	// {
-	// 	`SHOW COLLATION`,
-	// 	[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
-	// },
-	// {
-	// 	`SHOW COLLATION LIKE 'foo'`,
-	// 	nil,
-	// },
-	// {
-	// 	`SHOW COLLATION LIKE 'utf8%'`,
-	// 	[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
-	// },
-	// {
-	// 	`SHOW COLLATION WHERE charset = 'foo'`,
-	// 	nil,
-	// },
-	// {
-	// 	"SHOW COLLATION WHERE `Default` = 'Yes'",
-	// 	[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
-	// },
-	// {
-	// 	"ROLLBACK",
-	// 	nil,
-	// },
-	// {
-	// 	"SELECT substring(s, 1, 1) FROM mytable ORDER BY substring(s, 1, 1)",
-	// 	[]sql.Row{{"f"}, {"s"}, {"t"}},
-	// },
-	// {
-	// 	"SELECT substring(s, 1, 1), count(*) FROM mytable GROUP BY substring(s, 1, 1)",
-	// 	[]sql.Row{{"f", int64(1)}, {"s", int64(1)}, {"t", int64(1)}},
-	// },
-	// {
-	// 	"SELECT SLEEP(0.5)",
-	// 	[]sql.Row{{int(0)}},
-	// },
-	// {
-	// 	"SELECT TO_BASE64('foo')",
-	// 	[]sql.Row{{string("Zm9v")}},
-	// },
-	// {
-	// 	"SELECT FROM_BASE64('YmFy')",
-	// 	[]sql.Row{{string("bar")}},
-	// },
-	// {
-	// 	"SELECT DATE_ADD('2018-05-02', INTERVAL 1 DAY)",
-	// 	[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
-	// },
-	// {
-	// 	"SELECT DATE_SUB('2018-05-02', INTERVAL 1 DAY)",
-	// 	[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
-	// },
-	// {
-	// 	"SELECT '2018-05-02' + INTERVAL 1 DAY",
-	// 	[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
-	// },
-	// {
-	// 	"SELECT '2018-05-02' - INTERVAL 1 DAY",
-	// 	[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
-	// },
-	// {
-	// 	`SELECT i AS i FROM mytable ORDER BY i`,
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	`
-	// 	SELECT
-	// 		i,
-	// 		foo
-	// 	FROM (
-	// 		SELECT
-	// 			i,
-	// 			COUNT(s) AS foo
-	// 		FROM mytable
-	// 		GROUP BY i
-	// 	) AS q
-	// 	ORDER BY foo DESC
-	// 	`,
-	// 	[]sql.Row{
-	// 		{int64(1), int64(1)},
-	// 		{int64(2), int64(1)},
-	// 		{int64(3), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT n, COUNT(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
-	// 	[]sql.Row{{int64(1), int64(3)}, {int64(2), int64(3)}},
-	// },
-	// {
-	// 	"SELECT n, MAX(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
-	// 	[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(2)}},
-	// },
-	// {
-	// 	"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
-	// 	[]sql.Row{{"secon"}},
-	// },
-	// {
-	// 	"SELECT s,  i FROM mytable GROUP BY i ORDER BY SUBSTRING(s, 1, 1) DESC",
-	// 	[]sql.Row{
-	// 		{string("third row"), int64(3)},
-	// 		{string("second row"), int64(2)},
-	// 		{string("first row"), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT s, i FROM mytable GROUP BY i HAVING count(*) > 0 ORDER BY SUBSTRING(s, 1, 1) DESC",
-	// 	[]sql.Row{
-	// 		{string("third row"), int64(3)},
-	// 		{string("second row"), int64(2)},
-	// 		{string("first row"), int64(1)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT CONVERT('9999-12-31 23:59:59', DATETIME)",
-	// 	[]sql.Row{{time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)}},
-	// },
-	// {
-	// 	"SELECT CONVERT('10000-12-31 23:59:59', DATETIME)",
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	"SELECT '9999-12-31 23:59:59' + INTERVAL 1 DAY",
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	"SELECT DATE_ADD('9999-12-31 23:59:59', INTERVAL 1 DAY)",
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) AS date_col) t WHERE t.date_col > '0000-01-01 00:00:00'`,
-	// 	[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
-	// },
-	// {
-	// 	`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) as date_col) t GROUP BY t.date_col`,
-	// 	[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
-	// },
-	// {
-	// 	`SELECT i AS foo FROM mytable ORDER BY mytable.i`,
-	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	// },
-	// {
-	// 	`SELECT JSON_EXTRACT('[1, 2, 3]', '$.[0]')`,
-	// 	[]sql.Row{{float64(1)}},
-	// },
-	// {
-	// 	`SELECT ARRAY_LENGTH(JSON_EXTRACT('[1, 2, 3]', '$'))`,
-	// 	[]sql.Row{{int32(3)}},
-	// },
-	// {
-	// 	`SELECT ARRAY_LENGTH(JSON_EXTRACT('[{"i":0}, {"i":1, "y":"yyy"}, {"i":2, "x":"xxx"}]', '$.i'))`,
-	// 	[]sql.Row{{int32(3)}},
-	// },
-	// {
-	// 	`SELECT GREATEST(1, 2, 3, 4)`,
-	// 	[]sql.Row{{int64(4)}},
-	// },
-	// {
-	// 	`SELECT GREATEST(1, 2, "3", 4)`,
-	// 	[]sql.Row{{float64(4)}},
-	// },
-	// {
-	// 	`SELECT GREATEST(1, 2, "9", "foo999")`,
-	// 	[]sql.Row{{float64(9)}},
-	// },
-	// {
-	// 	`SELECT GREATEST("aaa", "bbb", "ccc")`,
-	// 	[]sql.Row{{"ccc"}},
-	// },
-	// {
-	// 	`SELECT GREATEST(i, s) FROM mytable`,
-	// 	[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
-	// },
-	// {
-	// 	`SELECT LEAST(1, 2, 3, 4)`,
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	`SELECT LEAST(1, 2, "3", 4)`,
-	// 	[]sql.Row{{float64(1)}},
-	// },
-	// {
-	// 	`SELECT LEAST(1, 2, "9", "foo999")`,
-	// 	[]sql.Row{{float64(1)}},
-	// },
-	// {
-	// 	`SELECT LEAST("aaa", "bbb", "ccc")`,
-	// 	[]sql.Row{{"aaa"}},
-	// },
-	// {
-	// 	`SELECT LEAST(i, s) FROM mytable`,
-	// 	[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
-	// },
-	// {
-	// 	"SELECT i, i2, s2 FROM mytable LEFT JOIN othertable ON i = i2 - 1",
-	// 	[]sql.Row{
-	// 		{int64(1), int64(2), "second"},
-	// 		{int64(2), int64(3), "first"},
-	// 		{int64(3), nil, nil},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i, i2, s2 FROM mytable RIGHT JOIN othertable ON i = i2 - 1",
-	// 	[]sql.Row{
-	// 		{nil, int64(1), "third"},
-	// 		{int64(1), int64(2), "second"},
-	// 		{int64(2), int64(3), "first"},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i, i2, s2 FROM mytable LEFT OUTER JOIN othertable ON i = i2 - 1",
-	// 	[]sql.Row{
-	// 		{int64(1), int64(2), "second"},
-	// 		{int64(2), int64(3), "first"},
-	// 		{int64(3), nil, nil},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i, i2, s2 FROM mytable RIGHT OUTER JOIN othertable ON i = i2 - 1",
-	// 	[]sql.Row{
-	// 		{nil, int64(1), "third"},
-	// 		{int64(1), int64(2), "second"},
-	// 		{int64(2), int64(3), "first"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT CHAR_LENGTH('áé'), LENGTH('àè')`,
-	// 	[]sql.Row{{int32(2), int32(4)}},
-	// },
-	// {
-	// 	"SELECT i, COUNT(i) AS `COUNT(i)` FROM (SELECT i FROM mytable) t GROUP BY i ORDER BY i, `COUNT(i)` DESC",
-	// 	[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(1)}, {int64(3), int64(1)}},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NOT s ORDER BY 1 DESC",
-	// 	[]sql.Row{
-	// 		{int64(3)},
-	// 		{int64(2)},
-	// 		{int64(1)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT i FROM mytable WHERE NOT(NOT i) ORDER BY 1 DESC",
-	// 	[]sql.Row{
-	// 		{int64(3)},
-	// 		{int64(2)},
-	// 		{int64(1)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT NOW() - NOW()`,
-	// 	[]sql.Row{{int64(0)}},
-	// },
-	// {
-	// 	`SELECT NOW() - (NOW() - INTERVAL 1 SECOND)`,
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	`SELECT SUBSTR(SUBSTRING('0123456789ABCDEF', 1, 10), -4)`,
-	// 	[]sql.Row{{"6789"}},
-	// },
-	// {
-	// 	`SELECT CASE i WHEN 1 THEN i ELSE NULL END FROM mytable`,
-	// 	[]sql.Row{{int64(1)}, {nil}, {nil}},
-	// },
-	// {
-	// 	`SELECT (NULL+1)`,
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	`SELECT ARRAY_LENGTH(null)`,
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	`SELECT ARRAY_LENGTH("foo")`,
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	`SELECT * FROM mytable WHERE NULL AND i = 3`,
-	// 	nil,
-	// },
-	// {
-	// 	`SELECT 1 FROM mytable GROUP BY i HAVING i > 1`,
-	// 	[]sql.Row{{int8(1)}, {int8(1)}},
-	// },
-	// {
-	// 	`SELECT avg(i) FROM mytable GROUP BY i HAVING avg(i) > 1`,
-	// 	[]sql.Row{{float64(2)}, {float64(3)}},
-	// },
-	// {
-	// 	`SELECT s AS s, COUNT(*) AS count,  AVG(i) AS ` + "`AVG(i)`" + `
-	// 	FROM  (
-	// 		SELECT * FROM mytable
-	// 	) AS expr_qry
-	// 	GROUP BY s
-	// 	HAVING ((AVG(i) > 0))
-	// 	ORDER BY count DESC
-	// 	LIMIT 10000`,
-	// 	[]sql.Row{
-	// 		{"first row", int64(1), float64(1)},
-	// 		{"second row", int64(1), float64(2)},
-	// 		{"third row", int64(1), float64(3)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT FIRST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	`SELECT LAST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	`SELECT COUNT(DISTINCT t.i) FROM tabletest t, mytable t2`,
-	// 	[]sql.Row{{int64(3)}},
-	// },
-	// {
-	// 	`SELECT CASE WHEN NULL THEN "yes" ELSE "no" END AS test`,
-	// 	[]sql.Row{{"no"}},
-	// },
-	// {
-	// 	`SELECT
-	// 		table_schema,
-	// 		table_name,
-	// 		CASE
-	// 			WHEN table_type = 'BASE TABLE' THEN
-	// 				CASE
-	// 					WHEN table_schema = 'mysql'
-	// 						OR table_schema = 'performance_schema' THEN 'SYSTEM TABLE'
-	// 					ELSE 'TABLE'
-	// 				END
-	// 			WHEN table_type = 'TEMPORARY' THEN 'LOCAL_TEMPORARY'
-	// 			ELSE table_type
-	// 		END AS TABLE_TYPE
-	// 	FROM information_schema.tables
-	// 	WHERE table_schema = 'mydb'
-	// 		AND table_name = 'mytable'
-	// 	HAVING table_type IN ('TABLE', 'VIEW')
-	// 	ORDER BY table_type, table_schema, table_name`,
-	// 	[]sql.Row{{"mydb", "mytable", "TABLE"}},
-	// },
-	// {
-	// 	`SELECT REGEXP_MATCHES("bopbeepbop", "bop")`,
-	// 	[]sql.Row{{[]interface{}{"bop", "bop"}}},
-	// },
-	// {
-	// 	`SELECT EXPLODE(REGEXP_MATCHES("bopbeepbop", "bop"))`,
-	// 	[]sql.Row{{"bop"}, {"bop"}},
-	// },
-	// {
-	// 	`SELECT EXPLODE(REGEXP_MATCHES("helloworld", "bop"))`,
-	// 	nil,
-	// },
-	// {
-	// 	`SELECT EXPLODE(REGEXP_MATCHES("", ""))`,
-	// 	[]sql.Row{{""}},
-	// },
-	// {
-	// 	`SELECT REGEXP_MATCHES(NULL, "")`,
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	`SELECT REGEXP_MATCHES("", NULL)`,
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	`SELECT REGEXP_MATCHES("", "", NULL)`,
-	// 	[]sql.Row{{nil}},
-	// },
-	// {
-	// 	"SELECT * FROM newlinetable WHERE s LIKE '%text%'",
-	// 	[]sql.Row{
-	// 		{int64(1), "\nthere is some text IN here"},
-	// 		{int64(2), "there is some\ntext IN here"},
-	// 		{int64(3), "there is some text\nin here"},
-	// 		{int64(4), "there is some text IN here\n"},
-	// 		{int64(5), "there is some text IN here"},
-	// 	},
-	// },
-	// {
-	// 	`SELECT i FROM mytable WHERE i = (SELECT 1)`,
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	`SELECT i FROM mytable WHERE i IN (SELECT i FROM mytable)`,
-	// 	[]sql.Row{
-	// 		{int64(1)},
-	// 		{int64(2)},
-	// 		{int64(3)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT i FROM mytable WHERE i NOT IN (SELECT i FROM mytable ORDER BY i ASC LIMIT 2)`,
-	// 	[]sql.Row{
-	// 		{int64(3)},
-	// 	},
-	// },
-	// {
-	// 	`SELECT (SELECT i FROM mytable ORDER BY i ASC LIMIT 1) AS x`,
-	// 	[]sql.Row{{int64(1)}},
-	// },
-	// {
-	// 	`SELECT DISTINCT n FROM bigtable ORDER BY t`,
-	// 	[]sql.Row{
-	// 		{int64(1)},
-	// 		{int64(9)},
-	// 		{int64(7)},
-	// 		{int64(3)},
-	// 		{int64(2)},
-	// 		{int64(8)},
-	// 		{int64(6)},
-	// 		{int64(5)},
-	// 		{int64(4)},
-	// 	},
-	// },
-	// {
-	// 	"SELECT pk,pk1,pk2 FROM one_pk, two_pk ORDER BY 1,2,3",
-	// 	[]sql.Row{
-	// 		{0, 0, 0},
-	// 		{0, 0, 1},
-	// 		{0, 1, 0},
-	// 		{0, 1, 1},
-	// 		{1, 0, 0},
-	// 		{1, 0, 1},
-	// 		{1, 1, 0},
-	// 		{1, 1, 1},
-	// 		{2, 0, 0},
-	// 		{2, 0, 1},
-	// 		{2, 1, 0},
-	// 		{2, 1, 1},
-	// 		{3, 0, 0},
-	// 		{3, 0, 1},
-	// 		{3, 1, 0},
-	// 		{3, 1, 1},
-	// 	},
-	// },
-	// {
-	// 	"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 AND pk2=1 ORDER BY 1,2",
-	// 	[]sql.Row{
-	// 		{0, 30},
-	// 		{10, 30},
-	// 		{20, 30},
-	// 		{30, 30},
-	// 	},
-	// },
-	// {
-	// 	"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 OR pk2=1 ORDER BY 1,2",
-	// 	[]sql.Row{
-	// 		{0, 10},
-	// 		{0, 20},
-	// 		{0, 30},
-	// 		{10, 10},
-	// 		{10, 20},
-	// 		{10, 30},
-	// 		{20, 10},
-	// 		{20, 20},
-	// 		{20, 30},
-	// 		{30, 10},
-	// 		{30, 20},
-	// 		{30, 30},
-	// 	},
-	// },
-	// {
-	// 	"SELECT pk,pk2 FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2",
-	// 	[]sql.Row{
-	// 		{1, 1},
-	// 		{1, 1},
-	// 	},
-	// },
-	// {
-	// 	"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE pk=0 AND pk1=0 OR pk2=1 ORDER BY 1,2,3",
-	// 	[]sql.Row{
-	// 		{0, 0, 0},
-	// 		{0, 0, 1},
-	// 		{0, 1, 1},
-	// 		{1, 0, 1},
-	// 		{1, 1, 1},
-	// 		{2, 0, 1},
-	// 		{2, 1, 1},
-	// 		{3, 0, 1},
-	// 		{3, 1, 1},
-	// 	},
-	// },
-	// {
-	// 	"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
-	// 	[]sql.Row{
-	// 		{0, 0, 0},
-	// 		{1, 0, 1},
-	// 		{2, 1, 0},
-	// 		{3, 1, 1},
-	// 	},
-	// },
-	// {
-	// 	"SELECT one_pk.c5,pk1,pk2 FROM one_pk,two_pk WHERE pk=pk1 ORDER BY 1,2,3",
-	// 	[]sql.Row{
-	// 		{0, 0, 0},
-	// 		{0, 0, 1},
-	// 		{10, 1, 0},
-	// 		{10, 1, 1},
-	// 	},
-	// },
-	// {
-	// 	"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
-	// 	[]sql.Row{
-	// 		{1, 0, 1},
-	// 	},
-	// },
-	// {
-	// 	"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk on pk=pk1 ORDER BY 1,2,3",
-	// 	[]sql.Row{
-	// 		{0, 0, 0},
-	// 		{0, 0, 1},
-	// 		{1, 1, 0},
-	// 		{1, 1, 1},
-	// 		{2, nil, nil},
-	// 		{3, nil, nil},
-	// 	},
-	// },
+	{
+		"SELECT i FROM mytable;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		"SELECT s,i FROM mytable;",
+		[]sql.Row{
+			{"first row", int64(1)},
+			{"second row", int64(2)},
+			{"third row", int64(3)}},
+	},
+	{
+		"SELECT s,i FROM (select i,s FROM mytable) mt;",
+		[]sql.Row{
+			{"first row", int64(1)},
+			{"second row", int64(2)},
+			{"third row", int64(3)}},
+	},
+	{
+		"SELECT i + 1 FROM mytable;",
+		[]sql.Row{{int64(2)}, {int64(3)}, {int64(4)}},
+	},
+	{
+		"SELECT -i FROM mytable;",
+		[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
+	},
+	{
+		"SELECT +i FROM mytable;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		"SELECT + - i FROM mytable;",
+		[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE -i = -2;",
+		[]sql.Row{{int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i = 2;",
+		[]sql.Row{{int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i > 2;",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i < 2;",
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i <> 2;",
+		[]sql.Row{{int64(1)}, {int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i IN (1, 3)",
+		[]sql.Row{{int64(1)}, {int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i = 1 OR i = 3",
+		[]sql.Row{{int64(1)}, {int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i >= 2 ORDER BY 1",
+		[]sql.Row{{int64(2)}, {int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i <= 2 ORDER BY 1",
+		[]sql.Row{{int64(1)}, {int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i > 2",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i < 2",
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i >= 2 OR i = 1 ORDER BY 1",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		"SELECT f32 FROM floattable WHERE f64 = 2.0;",
+		[]sql.Row{{float32(2.0)}},
+	},
+	{
+		"SELECT f32 FROM floattable WHERE f64 < 2.0;",
+		[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}},
+	},
+	{
+		"SELECT f32 FROM floattable WHERE f64 > 2.0;",
+		[]sql.Row{{float32(2.5)}},
+	},
+	{
+		"SELECT f32 FROM floattable WHERE f64 <> 2.0;",
+		[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}, {float32(2.5)}},
+	},
+	{
+		"SELECT f64 FROM floattable WHERE f32 = 2.0;",
+		[]sql.Row{{float64(2.0)}},
+	},
+	{
+		"SELECT f64 FROM floattable WHERE f32 = -1.5;",
+		[]sql.Row{{float64(-1.5)}},
+	},
+	{
+		"SELECT f64 FROM floattable WHERE -f32 = -2.0;",
+		[]sql.Row{{float64(2.0)}},
+	},
+	{
+		"SELECT f64 FROM floattable WHERE f32 < 2.0;",
+		[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}},
+	},
+	{
+		"SELECT f64 FROM floattable WHERE f32 > 2.0;",
+		[]sql.Row{{float64(2.5)}},
+	},
+	{
+		"SELECT f64 FROM floattable WHERE f32 <> 2.0;",
+		[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}, {float64(2.5)}},
+	},
+	{
+		"SELECT f32 FROM floattable ORDER BY f64;",
+		[]sql.Row{{float32(-1.5)}, {float32(-1.0)}, {float32(1.0)}, {float32(1.5)}, {float32(2.0)}, {float32(2.5)}},
+	},
+	{
+		"SELECT i FROM mytable ORDER BY i DESC;",
+		[]sql.Row{{int64(3)}, {int64(2)}, {int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE 'hello';",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable WHERE NOT 'hello';",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC;",
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable ORDER BY i LIMIT 1 OFFSET 1;",
+		[]sql.Row{{int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable ORDER BY i LIMIT 1,1;",
+		[]sql.Row{{int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable ORDER BY i LIMIT 3,1;",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable ORDER BY i LIMIT 2,100;",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT i FROM niltable WHERE b IS NULL",
+		[]sql.Row{{int64(2)}, {nil}},
+	},
+	{
+		"SELECT i FROM niltable WHERE b IS NOT NULL",
+		[]sql.Row{{int64(1)}, {nil}, {int64(4)}},
+	},
+	{
+		"SELECT i FROM niltable WHERE b",
+		[]sql.Row{{int64(1)}, {int64(4)}},
+	},
+	{
+		"SELECT i FROM niltable WHERE NOT b",
+		[]sql.Row{{nil}},
+	},
+	{
+		"SELECT i FROM niltable WHERE b IS TRUE",
+		[]sql.Row{{int64(1)}, {int64(4)}},
+	},
+	{
+		"SELECT i FROM niltable WHERE b IS NOT TRUE",
+		[]sql.Row{{int64(2)}, {nil}, {nil}},
+	},
+	{
+		"SELECT f FROM niltable WHERE b IS FALSE",
+		[]sql.Row{{3.0}},
+	},
+	{
+		"SELECT i FROM niltable WHERE b IS NOT FALSE",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(4)}, {nil}},
+	},
+	{
+		"SELECT COUNT(*) FROM mytable;",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT COUNT(*) FROM mytable LIMIT 1;",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT COUNT(*) AS c FROM mytable;",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT substring(s, 2, 3) FROM mytable",
+		[]sql.Row{{"irs"}, {"eco"}, {"hir"}},
+	},
+	{
+		`SELECT substring("foo", 2, 2)`,
+		[]sql.Row{{"oo"}},
+	},
+	{
+		`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', 2)`,
+		[]sql.Row{
+			{"a.b"},
+		},
+	},
+	{
+		`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', -2)`,
+		[]sql.Row{
+			{"e.f"},
+		},
+	},
+	{
+		`SELECT SUBSTRING_INDEX(SUBSTRING_INDEX('source{d}', '{d}', 1), 'r', -1)`,
+		[]sql.Row{
+			{"ce"},
+		},
+	},
+	{
+		`SELECT SUBSTRING_INDEX(mytable.s, "d", 1) AS s FROM mytable INNER JOIN othertable ON (SUBSTRING_INDEX(mytable.s, "d", 1) = SUBSTRING_INDEX(othertable.s2, "d", 1)) GROUP BY 1 HAVING s = 'secon'`,
+		[]sql.Row{{"secon"}},
+	},
+	{
+		"SELECT YEAR('2007-12-11') FROM mytable",
+		[]sql.Row{{int32(2007)}, {int32(2007)}, {int32(2007)}},
+	},
+	{
+		"SELECT MONTH('2007-12-11') FROM mytable",
+		[]sql.Row{{int32(12)}, {int32(12)}, {int32(12)}},
+	},
+	{
+		"SELECT DAY('2007-12-11') FROM mytable",
+		[]sql.Row{{int32(11)}, {int32(11)}, {int32(11)}},
+	},
+	{
+		"SELECT HOUR('2007-12-11 20:21:22') FROM mytable",
+		[]sql.Row{{int32(20)}, {int32(20)}, {int32(20)}},
+	},
+	{
+		"SELECT MINUTE('2007-12-11 20:21:22') FROM mytable",
+		[]sql.Row{{int32(21)}, {int32(21)}, {int32(21)}},
+	},
+	{
+		"SELECT SECOND('2007-12-11 20:21:22') FROM mytable",
+		[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
+	},
+	{
+		"SELECT DAYOFYEAR('2007-12-11 20:21:22') FROM mytable",
+		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	},
+	{
+		"SELECT SECOND('2007-12-11T20:21:22Z') FROM mytable",
+		[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
+	},
+	{
+		"SELECT DAYOFYEAR('2007-12-11') FROM mytable",
+		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	},
+	{
+		"SELECT DAYOFYEAR('20071211') FROM mytable",
+		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	},
+	{
+		"SELECT YEARWEEK('0000-01-01')",
+		[]sql.Row{{int32(1)}},
+	},
+	{
+		"SELECT YEARWEEK('9999-12-31')",
+		[]sql.Row{{int32(999952)}},
+	},
+	{
+		"SELECT YEARWEEK('2008-02-20', 1)",
+		[]sql.Row{{int32(200808)}},
+	},
+	{
+		"SELECT YEARWEEK('1987-01-01')",
+		[]sql.Row{{int32(198652)}},
+	},
+	{
+		"SELECT YEARWEEK('1987-01-01', 20), YEARWEEK('1987-01-01', 1), YEARWEEK('1987-01-01', 2), YEARWEEK('1987-01-01', 3), YEARWEEK('1987-01-01', 4), YEARWEEK('1987-01-01', 5), YEARWEEK('1987-01-01', 6), YEARWEEK('1987-01-01', 7)",
+		[]sql.Row{{int32(198653), int32(198701), int32(198652), int32(198701), int32(198653), int32(198652), int32(198653), int32(198652)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i BETWEEN 1 AND 2",
+		[]sql.Row{{int64(1)}, {int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE i NOT BETWEEN 1 AND 2",
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
+		[]sql.Row{
+			{"third"},
+			{"secon"},
+			{"first"},
+		},
+	},
+	{
+		"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{int64(1), int64(1), "third"},
+			{int64(2), int64(2), "second"},
+			{int64(3), int64(3), "first"},
+		},
+	},
+	{
+		"SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{"third", int64(1), int64(1)},
+			{"second", int64(2), int64(2)},
+			{ "first", int64(3), int64(3)},
+		},
+	},
+	{
+		"SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{int64(1), int64(1), "third"},
+			{int64(2), int64(2), "second"},
+			{int64(3), int64(3), "first"},
+		},
+	},
+	{
+		"SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
+		[]sql.Row{
+			{"third", int64(1), int64(1)},
+			{"second", int64(2), int64(2)},
+			{ "first", int64(3), int64(3)},
+		},
+	},
+	{
+		"SELECT substring(s2, 1), substring(s2, 2), substring(s2, 3) FROM othertable ORDER BY i2",
+		[]sql.Row{
+			{"third", "hird", "ird"},
+			{"second", "econd", "cond"},
+			{"first", "irst", "rst"},
+		},
+	},
+	{
+		`SELECT substring("first", 1), substring("second", 2), substring("third", 3)`,
+		[]sql.Row{
+			{"first", "econd", "ird"},
+		},
+	},
+	{
+		"SELECT substring(s2, -1), substring(s2, -2), substring(s2, -3) FROM othertable ORDER BY i2",
+		[]sql.Row{
+			{"d", "rd", "ird"},
+			{"d", "nd", "ond"},
+			{"t", "st", "rst"},
+		},
+	},
+	{
+		`SELECT substring("first", -1), substring("second", -2), substring("third", -3)`,
+		[]sql.Row{
+			{"t", "nd", "ird"},
+		},
+	},
+	{
+		"SELECT s FROM mytable INNER JOIN othertable " +
+				"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
+		[]sql.Row{
+			{"first row"},
+			{"second row"},
+			{"third row"},
+		},
+	},
+	{
+		`SELECT COUNT(*) AS cnt, fi FROM (
+			SELECT tbl.s AS fi
+			FROM mytable tbl
+		) t
+		GROUP BY fi`,
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(1), "second row"},
+			{int64(1), "third row"},
+		},
+	},
+	{
+		`SELECT fi, COUNT(*) FROM (
+			SELECT tbl.s AS fi
+			FROM mytable tbl
+		) t
+		GROUP BY fi
+		ORDER BY COUNT(*) ASC`,
+		[]sql.Row{
+			{"first row", int64(1)},
+			{"second row", int64(1)},
+			{"third row", int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*), fi  FROM (
+			SELECT tbl.s AS fi
+			FROM mytable tbl
+		) t
+		GROUP BY fi
+		ORDER BY COUNT(*) ASC`,
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(1), "second row"},
+			{int64(1), "third row"},
+		},
+	},
+	{
+		`SELECT COUNT(*) AS cnt, fi FROM (
+			SELECT tbl.s AS fi
+			FROM mytable tbl
+		) t
+		GROUP BY 2`,
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(1), "second row"},
+			{int64(1), "third row"},
+		},
+	},
+	{
+		`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY fi`,
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(1), "second row"},
+			{int64(1), "third row"},
+		},
+	},
+	{
+		`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY 2`,
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(1), "second row"},
+			{int64(1), "third row"},
+		},
+	},
+	{
+		"SELECT CAST(-3 AS UNSIGNED) FROM mytable",
+		[]sql.Row{
+			{uint64(18446744073709551613)},
+			{uint64(18446744073709551613)},
+			{uint64(18446744073709551613)},
+		},
+	},
+	{
+		"SELECT CONVERT(-3, UNSIGNED) FROM mytable",
+		[]sql.Row{
+			{uint64(18446744073709551613)},
+			{uint64(18446744073709551613)},
+			{uint64(18446744073709551613)},
+		},
+	},
+	{
+		"SELECT '3' > 2 FROM tabletest",
+		[]sql.Row{
+			{true},
+			{true},
+			{true},
+		},
+	},
+	{
+		"SELECT s > 2 FROM tabletest",
+		[]sql.Row{
+			{false},
+			{false},
+			{false},
+		},
+	},
+	{
+		"SELECT * FROM tabletest WHERE s > 0",
+		nil,
+	},
+	{
+		"SELECT * FROM tabletest WHERE s = 0",
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(2), "second row"},
+			{int64(3), "third row"},
+		},
+	},
+	{
+		"SELECT * FROM tabletest WHERE s = 'first row'",
+		[]sql.Row{
+			{int64(1), "first row"},
+		},
+	},
+	{
+		"SELECT s FROM mytable WHERE i IN (1, 2, 5)",
+		[]sql.Row{
+			{"first row"},
+			{"second row"},
+		},
+	},
+	{
+		"SELECT s FROM mytable WHERE i NOT IN (1, 2, 5)",
+		[]sql.Row{
+			{"third row"},
+		},
+	},
+	{
+		"SELECT 1 + 2",
+		[]sql.Row{
+			{int64(3)},
+		},
+	},
+	{
+		`SELECT i AS foo FROM mytable WHERE foo NOT IN (1, 2, 5)`,
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		`SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
+		[]sql.Row{
+			{int64(1), "first row", int64(1), "first row", "third", int64(1)},
+			{int64(1), "first row", int64(2), "second row", "second", int64(2)},
+			{int64(1), "first row", int64(3), "third row", "first", int64(3)},
+			{int64(2), "second row", int64(1), "first row", "third", int64(1)},
+			{int64(2), "second row", int64(2), "second row", "second", int64(2)},
+			{int64(2), "second row", int64(3), "third row", "first", int64(3)},
+			{int64(3), "third row", int64(1), "first row", "third", int64(1)},
+			{int64(3), "third row", int64(2), "second row", "second", int64(2)},
+			{int64(3), "third row", int64(3), "third row", "first", int64(3)},
+		},
+	},
+	{
+		`SELECT split(s," ") FROM mytable`,
+		[]sql.Row{
+			sql.NewRow([]interface{}{"first", "row"}),
+			sql.NewRow([]interface{}{"second", "row"}),
+			sql.NewRow([]interface{}{"third", "row"}),
+		},
+	},
+	{
+		`SELECT split(s,"s") FROM mytable`,
+		[]sql.Row{
+			sql.NewRow([]interface{}{"fir", "t row"}),
+			sql.NewRow([]interface{}{"", "econd row"}),
+			sql.NewRow([]interface{}{"third row"}),
+		},
+	},
+	{
+		`SELECT SUM(i) FROM mytable`,
+		[]sql.Row{{float64(6)}},
+	},
+	{
+		`SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2`,
+		[]sql.Row{
+			{int64(3), "third row", "first", int64(3)},
+		},
+	},
+	{
+		`SELECT i AS foo FROM mytable ORDER BY i DESC`,
+		[]sql.Row{
+			{int64(3)},
+			{int64(2)},
+			{int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY i DESC`,
+		[]sql.Row{
+			{int64(1), int64(3)},
+			{int64(1), int64(2)},
+			{int64(1), int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY 2 DESC`,
+		[]sql.Row{
+			{int64(1), int64(3)},
+			{int64(1), int64(2)},
+			{int64(1), int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY foo DESC`,
+		[]sql.Row{
+			{int64(1), int64(3)},
+			{int64(1), int64(2)},
+			{int64(1), int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY foo DESC`,
+		[]sql.Row{
+			{int64(1), int64(3)},
+			{int64(1), int64(2)},
+			{int64(1), int64(1)},
+		},
+	},
+	{
+		`SELECT COUNT(*) c, i AS i FROM mytable GROUP BY 2`,
+		[]sql.Row{
+			{int64(1), int64(3)},
+			{int64(1), int64(2)},
+			{int64(1), int64(1)},
+		},
+	},
+	{
+		`SELECT i AS i FROM mytable GROUP BY 1`,
+		[]sql.Row{
+			{int64(3)},
+			{int64(2)},
+			{int64(1)},
+		},
+	},
+	{
+		`SELECT CONCAT("a", "b", "c")`,
+		[]sql.Row{
+			{string("abc")},
+		},
+	},
+	{
+		`SELECT COALESCE(NULL, NULL, NULL, 'example', NULL, 1234567890)`,
+		[]sql.Row{
+			{string("example")},
+		},
+	},
+	{
+		`SELECT COALESCE(NULL, NULL, NULL, COALESCE(NULL, 1234567890))`,
+		[]sql.Row{
+			{int32(1234567890)},
+		},
+	},
+	{
+		"SELECT concat(s, i) FROM mytable",
+		[]sql.Row{
+			{string("first row1")},
+			{string("second row2")},
+			{string("third row3")},
+		},
+	},
+	{
+		"SELECT version()",
+		[]sql.Row{
+			{string("8.0.11")},
+		},
+	},
+	{
+		"SELECT * FROM mytable WHERE 1 > 5",
+		nil,
+	},
+	{
+		"SELECT SUM(i) + 1, i FROM mytable GROUP BY i ORDER BY i",
+		[]sql.Row{
+			{float64(2), int64(1)},
+			{float64(3), int64(2)},
+			{float64(4), int64(3)},
+		},
+	},
+	{
+		"SELECT SUM(i), i FROM mytable GROUP BY i ORDER BY 1+SUM(i) ASC",
+		[]sql.Row{
+			{float64(1), int64(1)},
+			{float64(2), int64(2)},
+			{float64(3), int64(3)},
+		},
+	},
+	{
+		"SELECT i, SUM(i) FROM mytable GROUP BY i ORDER BY SUM(i) DESC",
+		[]sql.Row{
+			{int64(3), float64(3)},
+			{int64(2), float64(2)},
+			{int64(1), float64(1)},
+		},
+	},
+	{
+		`/*!40101 SET NAMES utf8 */`,
+		nil,
+	},
+	{
+		`SHOW DATABASES`,
+		[]sql.Row{{"mydb"}, {"foo"}},
+	},
+	{
+		`SHOW SCHEMAS`,
+		[]sql.Row{{"mydb"}, {"foo"}},
+	},
+	{
+		`SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA`,
+		[]sql.Row{
+			{"mydb", "utf8mb4", "utf8_bin"},
+			{"foo", "utf8mb4", "utf8_bin"},
+		},
+	},
+	{
+		`SELECT s FROM mytable WHERE s LIKE '%d row'`,
+		[]sql.Row{
+			{"second row"},
+			{"third row"},
+		},
+	},
+	{
+		`SELECT SUBSTRING(s, -3, 3) AS s FROM mytable WHERE s LIKE '%d row' GROUP BY 1`,
+		[]sql.Row{
+			{"row"},
+		},
+	},
+	{
+		`SELECT s FROM mytable WHERE s NOT LIKE '%d row'`,
+		[]sql.Row{
+			{"first row"},
+		},
+	},
+	{
+		`SHOW COLUMNS FROM mytable`,
+		[]sql.Row{
+			{"i", "BIGINT", "NO", "", "", ""},
+			{"s", "TEXT", "NO", "", "", ""},
+		},
+	},
+	{
+		`DESCRIBE mytable`,
+		[]sql.Row{
+			{"i", "BIGINT", "NO", "", "", ""},
+			{"s", "TEXT", "NO", "", "", ""},
+		},
+	},
+	{
+		`DESC mytable`,
+		[]sql.Row{
+			{"i", "BIGINT", "NO", "", "", ""},
+			{"s", "TEXT", "NO", "", "", ""},
+		},
+	},
+	{
+		`SHOW COLUMNS FROM one_pk`,
+		[]sql.Row{
+			{"pk", "TINYINT", "NO", "PRI", "", ""},
+			{"c1", "TINYINT", "NO", "", "", ""},
+			{"c2", "TINYINT", "NO", "", "", ""},
+			{"c3", "TINYINT", "NO", "", "", ""},
+			{"c4", "TINYINT", "NO", "", "", ""},
+			{"c5", "TINYINT", "NO", "", "", ""},
+		},
+	},
+	{
+		`DESCRIBE one_pk`,
+		[]sql.Row{
+			{"pk", "TINYINT", "NO", "PRI", "", ""},
+			{"c1", "TINYINT", "NO", "", "", ""},
+			{"c2", "TINYINT", "NO", "", "", ""},
+			{"c3", "TINYINT", "NO", "", "", ""},
+			{"c4", "TINYINT", "NO", "", "", ""},
+			{"c5", "TINYINT", "NO", "", "", ""},
+		},
+	},
+	{
+		`DESC one_pk`,
+		[]sql.Row{
+			{"pk", "TINYINT", "NO", "PRI", "", ""},
+			{"c1", "TINYINT", "NO", "", "", ""},
+			{"c2", "TINYINT", "NO", "", "", ""},
+			{"c3", "TINYINT", "NO", "", "", ""},
+			{"c4", "TINYINT", "NO", "", "", ""},
+			{"c5", "TINYINT", "NO", "", "", ""},
+		},
+	},
+
+	{
+		`SHOW COLUMNS FROM mytable WHERE Field = 'i'`,
+		[]sql.Row{
+			{"i", "BIGINT", "NO", "", "", ""},
+		},
+	},
+	{
+		`SHOW COLUMNS FROM mytable LIKE 'i'`,
+		[]sql.Row{
+			{"i", "BIGINT", "NO", "", "", ""},
+		},
+	},
+	{
+		`SHOW FULL COLUMNS FROM mytable`,
+		[]sql.Row{
+			{"i", "BIGINT", nil, "NO", "", "", "", "", ""},
+			{"s", "TEXT", "utf8_bin", "NO", "", "", "", "", ""},
+		},
+	},
+	{
+		`SHOW FULL COLUMNS FROM one_pk`,
+		[]sql.Row{
+			{"pk", "TINYINT", nil, "NO", "PRI", "", "", "", ""},
+			{"c1", "TINYINT", nil, "NO", "", "", "", "", ""},
+			{"c2", "TINYINT", nil, "NO", "", "", "", "", ""},
+			{"c3", "TINYINT", nil, "NO", "", "", "", "", ""},
+			{"c4", "TINYINT", nil, "NO", "", "", "", "", ""},
+			{"c5", "TINYINT", nil, "NO", "", "", "", "", "column 5"},
+		},
+	},
+	{
+		`SELECT * FROM foo.other_table`,
+		[]sql.Row{
+			{"a", int32(4)},
+			{"b", int32(2)},
+			{"c", int32(0)},
+		},
+	},
+	{
+		`SELECT AVG(23.222000)`,
+		[]sql.Row{
+			{float64(23.222)},
+		},
+	},
+	{
+		`SELECT DATABASE()`,
+		[]sql.Row{
+			{"mydb"},
+		},
+	},
+	{
+		`SHOW VARIABLES`,
+		[]sql.Row{
+			{"auto_increment_increment", int64(1)},
+			{"time_zone", time.Local.String()},
+			{"system_time_zone", time.Local.String()},
+			{"max_allowed_packet", math.MaxInt32},
+			{"sql_mode", ""},
+			{"gtid_mode", int32(0)},
+			{"collation_database", "utf8_bin"},
+			{"ndbinfo_version", ""},
+			{"sql_select_limit", math.MaxInt32},
+			{"transaction_isolation", "READ UNCOMMITTED"},
+			{"version", ""},
+			{"version_comment", ""},
+		},
+	},
+	{
+		`SHOW VARIABLES LIKE 'gtid_mode`,
+		[]sql.Row{
+			{"gtid_mode", int32(0)},
+		},
+	},
+	{
+		`SHOW VARIABLES LIKE 'gtid%`,
+		[]sql.Row{
+			{"gtid_mode", int32(0)},
+		},
+	},
+	{
+		`SHOW GLOBAL VARIABLES LIKE '%mode`,
+		[]sql.Row{
+			{"sql_mode", ""},
+			{"gtid_mode", int32(0)},
+		},
+	},
+	{
+		`SELECT JSON_EXTRACT("foo", "$")`,
+		[]sql.Row{{"foo"}},
+	},
+	{
+		`SELECT JSON_UNQUOTE('"foo"')`,
+		[]sql.Row{{"foo"}},
+	},
+	{
+		`SELECT JSON_UNQUOTE('[1, 2, 3]')`,
+		[]sql.Row{{"[1, 2, 3]"}},
+	},
+	{
+		`SELECT JSON_UNQUOTE('"\\t\\u0032"')`,
+		[]sql.Row{{"\t2"}},
+	},
+	{
+		`SELECT JSON_UNQUOTE('"\t\\u0032"')`,
+		[]sql.Row{{"\t2"}},
+	},
+	{
+		`SELECT CONNECTION_ID()`,
+		[]sql.Row{{uint32(1)}},
+	},
+	{
+		`SHOW CREATE DATABASE mydb`,
+		[]sql.Row{{
+			"mydb",
+			"CREATE DATABASE `mydb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */",
+		}},
+	},
+	{
+		`SELECT -1`,
+		[]sql.Row{{int8(-1)}},
+	},
+	{
+		`
+		SHOW WARNINGS
+		`,
+		nil,
+	},
+	{
+		`SHOW WARNINGS LIMIT 0`,
+		nil,
+	},
+	{
+		`SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
+		nil,
+	},
+	{
+		`SELECT NULL`,
+		[]sql.Row{
+			{nil},
+		},
+	},
+	{
+		`SELECT nullif('abc', NULL)`,
+		[]sql.Row{
+			{"abc"},
+		},
+	},
+	{
+		`SELECT nullif(NULL, NULL)`,
+		[]sql.Row{
+			{sql.Null},
+		},
+	},
+	{
+		`SELECT nullif(NULL, 123)`,
+		[]sql.Row{
+			{nil},
+		},
+	},
+	{
+		`SELECT nullif(123, 123)`,
+		[]sql.Row{
+			{sql.Null},
+		},
+	},
+	{
+		`SELECT nullif(123, 321)`,
+		[]sql.Row{
+			{int8(123)},
+		},
+	},
+	{
+		`SELECT ifnull(123, NULL)`,
+		[]sql.Row{
+			{int8(123)},
+		},
+	},
+	{
+		`SELECT ifnull(NULL, NULL)`,
+		[]sql.Row{
+			{nil},
+		},
+	},
+	{
+		`SELECT ifnull(NULL, 123)`,
+		[]sql.Row{
+			{int8(123)},
+		},
+	},
+	{
+		`SELECT ifnull(123, 123)`,
+		[]sql.Row{
+			{int8(123)},
+		},
+	},
+	{
+		`SELECT ifnull(123, 321)`,
+		[]sql.Row{
+			{int8(123)},
+		},
+	},
+	{
+		"SELECT i FROM mytable WHERE NULL > 10;",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable WHERE NULL IN (10);",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable WHERE NULL IN (NULL, NULL);",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable WHERE NOT NULL NOT IN (NULL);",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable WHERE NOT (NULL) <> 10;",
+		nil,
+	},
+	{
+		"SELECT i FROM mytable WHERE NOT NULL <> NULL;",
+		nil,
+	},
+	{
+		`SELECT round(15728640/1024/1024)`,
+		[]sql.Row{
+			{int64(15)},
+		},
+	},
+	{
+		`SELECT round(15, 1)`,
+		[]sql.Row{
+			{int8(15)},
+		},
+	},
+	{
+		`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'other' END FROM mytable`,
+		[]sql.Row{
+			{"one"},
+			{"two"},
+			{"other"},
+		},
+	},
+	{
+		`SELECT CASE WHEN i > 2 THEN 'more than two' WHEN i < 2 THEN 'less than two' ELSE 'two' END FROM mytable`,
+		[]sql.Row{
+			{"less than two"},
+			{"two"},
+			{"more than two"},
+		},
+	},
+	{
+		`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' END FROM mytable`,
+		[]sql.Row{
+			{"one"},
+			{"two"},
+			{nil},
+		},
+	},
+	{
+		`SHOW COLLATION`,
+		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
+	},
+	{
+		`SHOW COLLATION LIKE 'foo'`,
+		nil,
+	},
+	{
+		`SHOW COLLATION LIKE 'utf8%'`,
+		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
+	},
+	{
+		`SHOW COLLATION WHERE charset = 'foo'`,
+		nil,
+	},
+	{
+		"SHOW COLLATION WHERE `Default` = 'Yes'",
+		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
+	},
+	{
+		"ROLLBACK",
+		nil,
+	},
+	{
+		"SELECT substring(s, 1, 1) FROM mytable ORDER BY substring(s, 1, 1)",
+		[]sql.Row{{"f"}, {"s"}, {"t"}},
+	},
+	{
+		"SELECT substring(s, 1, 1), count(*) FROM mytable GROUP BY substring(s, 1, 1)",
+		[]sql.Row{{"f", int64(1)}, {"s", int64(1)}, {"t", int64(1)}},
+	},
+	{
+		"SELECT SLEEP(0.5)",
+		[]sql.Row{{int(0)}},
+	},
+	{
+		"SELECT TO_BASE64('foo')",
+		[]sql.Row{{string("Zm9v")}},
+	},
+	{
+		"SELECT FROM_BASE64('YmFy')",
+		[]sql.Row{{string("bar")}},
+	},
+	{
+		"SELECT DATE_ADD('2018-05-02', INTERVAL 1 DAY)",
+		[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		"SELECT DATE_SUB('2018-05-02', INTERVAL 1 DAY)",
+		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		"SELECT '2018-05-02' + INTERVAL 1 DAY",
+		[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		"SELECT '2018-05-02' - INTERVAL 1 DAY",
+		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		`SELECT i AS i FROM mytable ORDER BY i`,
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		`
+		SELECT
+			i,
+			foo
+		FROM (
+			SELECT
+				i,
+				COUNT(s) AS foo
+			FROM mytable
+			GROUP BY i
+		) AS q
+		ORDER BY foo DESC
+		`,
+		[]sql.Row{
+			{int64(1), int64(1)},
+			{int64(2), int64(1)},
+			{int64(3), int64(1)},
+		},
+	},
+	{
+		"SELECT n, COUNT(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
+		[]sql.Row{{int64(1), int64(3)}, {int64(2), int64(3)}},
+	},
+	{
+		"SELECT n, MAX(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
+		[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(2)}},
+	},
+	{
+		"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
+		[]sql.Row{{"secon"}},
+	},
+	{
+		"SELECT s,  i FROM mytable GROUP BY i ORDER BY SUBSTRING(s, 1, 1) DESC",
+		[]sql.Row{
+			{string("third row"), int64(3)},
+			{string("second row"), int64(2)},
+			{string("first row"), int64(1)},
+		},
+	},
+	{
+		"SELECT s, i FROM mytable GROUP BY i HAVING count(*) > 0 ORDER BY SUBSTRING(s, 1, 1) DESC",
+		[]sql.Row{
+			{string("third row"), int64(3)},
+			{string("second row"), int64(2)},
+			{string("first row"), int64(1)},
+		},
+	},
+	{
+		"SELECT CONVERT('9999-12-31 23:59:59', DATETIME)",
+		[]sql.Row{{time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)}},
+	},
+	{
+		"SELECT CONVERT('10000-12-31 23:59:59', DATETIME)",
+		[]sql.Row{{nil}},
+	},
+	{
+		"SELECT '9999-12-31 23:59:59' + INTERVAL 1 DAY",
+		[]sql.Row{{nil}},
+	},
+	{
+		"SELECT DATE_ADD('9999-12-31 23:59:59', INTERVAL 1 DAY)",
+		[]sql.Row{{nil}},
+	},
+	{
+		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) AS date_col) t WHERE t.date_col > '0000-01-01 00:00:00'`,
+		[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) as date_col) t GROUP BY t.date_col`,
+		[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
+		`SELECT i AS foo FROM mytable ORDER BY mytable.i`,
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		`SELECT JSON_EXTRACT('[1, 2, 3]', '$.[0]')`,
+		[]sql.Row{{float64(1)}},
+	},
+	{
+		`SELECT ARRAY_LENGTH(JSON_EXTRACT('[1, 2, 3]', '$'))`,
+		[]sql.Row{{int32(3)}},
+	},
+	{
+		`SELECT ARRAY_LENGTH(JSON_EXTRACT('[{"i":0}, {"i":1, "y":"yyy"}, {"i":2, "x":"xxx"}]', '$.i'))`,
+		[]sql.Row{{int32(3)}},
+	},
+	{
+		`SELECT GREATEST(1, 2, 3, 4)`,
+		[]sql.Row{{int64(4)}},
+	},
+	{
+		`SELECT GREATEST(1, 2, "3", 4)`,
+		[]sql.Row{{float64(4)}},
+	},
+	{
+		`SELECT GREATEST(1, 2, "9", "foo999")`,
+		[]sql.Row{{float64(9)}},
+	},
+	{
+		`SELECT GREATEST("aaa", "bbb", "ccc")`,
+		[]sql.Row{{"ccc"}},
+	},
+	{
+		`SELECT GREATEST(i, s) FROM mytable`,
+		[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
+	},
+	{
+		`SELECT LEAST(1, 2, 3, 4)`,
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		`SELECT LEAST(1, 2, "3", 4)`,
+		[]sql.Row{{float64(1)}},
+	},
+	{
+		`SELECT LEAST(1, 2, "9", "foo999")`,
+		[]sql.Row{{float64(1)}},
+	},
+	{
+		`SELECT LEAST("aaa", "bbb", "ccc")`,
+		[]sql.Row{{"aaa"}},
+	},
+	{
+		`SELECT LEAST(i, s) FROM mytable`,
+		[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
+	},
+	{
+		"SELECT i, i2, s2 FROM mytable LEFT JOIN othertable ON i = i2 - 1",
+		[]sql.Row{
+			{int64(1), int64(2), "second"},
+			{int64(2), int64(3), "first"},
+			{int64(3), nil, nil},
+		},
+	},
+	{
+		"SELECT i, i2, s2 FROM mytable RIGHT JOIN othertable ON i = i2 - 1",
+		[]sql.Row{
+			{nil, int64(1), "third"},
+			{int64(1), int64(2), "second"},
+			{int64(2), int64(3), "first"},
+		},
+	},
+	{
+		"SELECT i, i2, s2 FROM mytable LEFT OUTER JOIN othertable ON i = i2 - 1",
+		[]sql.Row{
+			{int64(1), int64(2), "second"},
+			{int64(2), int64(3), "first"},
+			{int64(3), nil, nil},
+		},
+	},
+	{
+		"SELECT i, i2, s2 FROM mytable RIGHT OUTER JOIN othertable ON i = i2 - 1",
+		[]sql.Row{
+			{nil, int64(1), "third"},
+			{int64(1), int64(2), "second"},
+			{int64(2), int64(3), "first"},
+		},
+	},
+	{
+		`SELECT CHAR_LENGTH('áé'), LENGTH('àè')`,
+		[]sql.Row{{int32(2), int32(4)}},
+	},
+	{
+		"SELECT i, COUNT(i) AS `COUNT(i)` FROM (SELECT i FROM mytable) t GROUP BY i ORDER BY i, `COUNT(i)` DESC",
+		[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(1)}, {int64(3), int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE NOT s ORDER BY 1 DESC",
+		[]sql.Row{
+			{int64(3)},
+			{int64(2)},
+			{int64(1)},
+		},
+	},
+	{
+		"SELECT i FROM mytable WHERE NOT(NOT i) ORDER BY 1 DESC",
+		[]sql.Row{
+			{int64(3)},
+			{int64(2)},
+			{int64(1)},
+		},
+	},
+	{
+		`SELECT NOW() - NOW()`,
+		[]sql.Row{{int64(0)}},
+	},
+	{
+		`SELECT NOW() - (NOW() - INTERVAL 1 SECOND)`,
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		`SELECT SUBSTR(SUBSTRING('0123456789ABCDEF', 1, 10), -4)`,
+		[]sql.Row{{"6789"}},
+	},
+	{
+		`SELECT CASE i WHEN 1 THEN i ELSE NULL END FROM mytable`,
+		[]sql.Row{{int64(1)}, {nil}, {nil}},
+	},
+	{
+		`SELECT (NULL+1)`,
+		[]sql.Row{{nil}},
+	},
+	{
+		`SELECT ARRAY_LENGTH(null)`,
+		[]sql.Row{{nil}},
+	},
+	{
+		`SELECT ARRAY_LENGTH("foo")`,
+		[]sql.Row{{nil}},
+	},
+	{
+		`SELECT * FROM mytable WHERE NULL AND i = 3`,
+		nil,
+	},
+	{
+		`SELECT 1 FROM mytable GROUP BY i HAVING i > 1`,
+		[]sql.Row{{int8(1)}, {int8(1)}},
+	},
+	{
+		`SELECT avg(i) FROM mytable GROUP BY i HAVING avg(i) > 1`,
+		[]sql.Row{{float64(2)}, {float64(3)}},
+	},
+	{
+		`SELECT s AS s, COUNT(*) AS count,  AVG(i) AS ` + "`AVG(i)`" + `
+		FROM  (
+			SELECT * FROM mytable
+		) AS expr_qry
+		GROUP BY s
+		HAVING ((AVG(i) > 0))
+		ORDER BY count DESC
+		LIMIT 10000`,
+		[]sql.Row{
+			{"first row", int64(1), float64(1)},
+			{"second row", int64(1), float64(2)},
+			{"third row", int64(1), float64(3)},
+		},
+	},
+	{
+		`SELECT FIRST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		`SELECT LAST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		`SELECT COUNT(DISTINCT t.i) FROM tabletest t, mytable t2`,
+		[]sql.Row{{int64(3)}},
+	},
+	{
+		`SELECT CASE WHEN NULL THEN "yes" ELSE "no" END AS test`,
+		[]sql.Row{{"no"}},
+	},
+	{
+		`SELECT
+			table_schema,
+			table_name,
+			CASE
+				WHEN table_type = 'BASE TABLE' THEN
+					CASE
+						WHEN table_schema = 'mysql'
+							OR table_schema = 'performance_schema' THEN 'SYSTEM TABLE'
+						ELSE 'TABLE'
+					END
+				WHEN table_type = 'TEMPORARY' THEN 'LOCAL_TEMPORARY'
+				ELSE table_type
+			END AS TABLE_TYPE
+		FROM information_schema.tables
+		WHERE table_schema = 'mydb'
+			AND table_name = 'mytable'
+		HAVING table_type IN ('TABLE', 'VIEW')
+		ORDER BY table_type, table_schema, table_name`,
+		[]sql.Row{{"mydb", "mytable", "TABLE"}},
+	},
+	{
+		`SELECT REGEXP_MATCHES("bopbeepbop", "bop")`,
+		[]sql.Row{{[]interface{}{"bop", "bop"}}},
+	},
+	{
+		`SELECT EXPLODE(REGEXP_MATCHES("bopbeepbop", "bop"))`,
+		[]sql.Row{{"bop"}, {"bop"}},
+	},
+	{
+		`SELECT EXPLODE(REGEXP_MATCHES("helloworld", "bop"))`,
+		nil,
+	},
+	{
+		`SELECT EXPLODE(REGEXP_MATCHES("", ""))`,
+		[]sql.Row{{""}},
+	},
+	{
+		`SELECT REGEXP_MATCHES(NULL, "")`,
+		[]sql.Row{{nil}},
+	},
+	{
+		`SELECT REGEXP_MATCHES("", NULL)`,
+		[]sql.Row{{nil}},
+	},
+	{
+		`SELECT REGEXP_MATCHES("", "", NULL)`,
+		[]sql.Row{{nil}},
+	},
+	{
+		"SELECT * FROM newlinetable WHERE s LIKE '%text%'",
+		[]sql.Row{
+			{int64(1), "\nthere is some text IN here"},
+			{int64(2), "there is some\ntext IN here"},
+			{int64(3), "there is some text\nin here"},
+			{int64(4), "there is some text IN here\n"},
+			{int64(5), "there is some text IN here"},
+		},
+	},
+	{
+		`SELECT i FROM mytable WHERE i = (SELECT 1)`,
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		`SELECT i FROM mytable WHERE i IN (SELECT i FROM mytable)`,
+		[]sql.Row{
+			{int64(1)},
+			{int64(2)},
+			{int64(3)},
+		},
+	},
+	{
+		`SELECT i FROM mytable WHERE i NOT IN (SELECT i FROM mytable ORDER BY i ASC LIMIT 2)`,
+		[]sql.Row{
+			{int64(3)},
+		},
+	},
+	{
+		`SELECT (SELECT i FROM mytable ORDER BY i ASC LIMIT 1) AS x`,
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		`SELECT DISTINCT n FROM bigtable ORDER BY t`,
+		[]sql.Row{
+			{int64(1)},
+			{int64(9)},
+			{int64(7)},
+			{int64(3)},
+			{int64(2)},
+			{int64(8)},
+			{int64(6)},
+			{int64(5)},
+			{int64(4)},
+		},
+	},
+	{
+		"SELECT pk,pk1,pk2 FROM one_pk, two_pk ORDER BY 1,2,3",
+		[]sql.Row{
+			{0, 0, 0},
+			{0, 0, 1},
+			{0, 1, 0},
+			{0, 1, 1},
+			{1, 0, 0},
+			{1, 0, 1},
+			{1, 1, 0},
+			{1, 1, 1},
+			{2, 0, 0},
+			{2, 0, 1},
+			{2, 1, 0},
+			{2, 1, 1},
+			{3, 0, 0},
+			{3, 0, 1},
+			{3, 1, 0},
+			{3, 1, 1},
+		},
+	},
+	{
+		"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 AND pk2=1 ORDER BY 1,2",
+		[]sql.Row{
+			{0, 30},
+			{10, 30},
+			{20, 30},
+			{30, 30},
+		},
+	},
+	{
+		"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 OR pk2=1 ORDER BY 1,2",
+		[]sql.Row{
+			{0, 10},
+			{0, 20},
+			{0, 30},
+			{10, 10},
+			{10, 20},
+			{10, 30},
+			{20, 10},
+			{20, 20},
+			{20, 30},
+			{30, 10},
+			{30, 20},
+			{30, 30},
+		},
+	},
+	{
+		"SELECT pk,pk2 FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2",
+		[]sql.Row{
+			{1, 1},
+			{1, 1},
+		},
+	},
+	{
+		"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE pk=0 AND pk1=0 OR pk2=1 ORDER BY 1,2,3",
+		[]sql.Row{
+			{0, 0, 0},
+			{0, 0, 1},
+			{0, 1, 1},
+			{1, 0, 1},
+			{1, 1, 1},
+			{2, 0, 1},
+			{2, 1, 1},
+			{3, 0, 1},
+			{3, 1, 1},
+		},
+	},
+	{
+		"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
+		[]sql.Row{
+			{0, 0, 0},
+			{1, 0, 1},
+			{2, 1, 0},
+			{3, 1, 1},
+		},
+	},
+	{
+		"SELECT one_pk.c5,pk1,pk2 FROM one_pk,two_pk WHERE pk=pk1 ORDER BY 1,2,3",
+		[]sql.Row{
+			{0, 0, 0},
+			{0, 0, 1},
+			{10, 1, 0},
+			{10, 1, 1},
+		},
+	},
+	{
+		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
+		[]sql.Row{
+			{1, 0, 1},
+		},
+	},
+	{
+		"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk on pk=pk1 ORDER BY 1,2,3",
+		[]sql.Row{
+			{0, 0, 0},
+			{0, 0, 1},
+			{1, 1, 0},
+			{1, 1, 1},
+			{2, nil, nil},
+			{3, nil, nil},
+		},
+	},
 	{
 		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i ORDER BY 1",
 		[]sql.Row{

--- a/engine_test.go
+++ b/engine_test.go
@@ -1433,11 +1433,11 @@ var queries = []queryTest{
 	{
 		"SELECT * FROM newlinetable WHERE s LIKE '%text%'",
 		[]sql.Row{
-			{int64(1), "\nthere is some text IN here"},
-			{int64(2), "there is some\ntext IN here"},
+			{int64(1), "\nthere is some text in here"},
+			{int64(2), "there is some\ntext in here"},
 			{int64(3), "there is some text\nin here"},
-			{int64(4), "there is some text IN here\n"},
-			{int64(5), "there is some text IN here"},
+			{int64(4), "there is some text in here\n"},
+			{int64(5), "there is some text in here"},
 		},
 	},
 	{
@@ -3949,11 +3949,11 @@ func allTestTables(t *testing.T, numPartitions int) map[string]*memory.Table {
 
 	insertRows(
 		t, tables["newlinetable"],
-		sql.NewRow(int64(1), "\nthere is some text IN here"),
-		sql.NewRow(int64(2), "there is some\ntext IN here"),
+		sql.NewRow(int64(1), "\nthere is some text in here"),
+		sql.NewRow(int64(2), "there is some\ntext in here"),
 		sql.NewRow(int64(3), "there is some text\nin here"),
-		sql.NewRow(int64(4), "there is some text IN here\n"),
-		sql.NewRow(int64(5), "there is some text IN here"),
+		sql.NewRow(int64(4), "there is some text in here\n"),
+		sql.NewRow(int64(5), "there is some text in here"),
 	)
 
 	tables["typestable"] = memory.NewPartitionedTable("typestable", sql.Schema{

--- a/engine_test.go
+++ b/engine_test.go
@@ -32,1553 +32,1553 @@ type queryTest struct {
 }
 
 var queries = []queryTest{
-	{
-		"SELECT i FROM mytable;",
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	},
-	{
-		"SELECT s,i FROM mytable;",
-		[]sql.Row{
-			{"first row", int64(1)},
-			{"second row", int64(2)},
-			{"third row", int64(3)}},
-	},
-	{
-		"SELECT s,i FROM (select i,s FROM mytable) mt;",
-		[]sql.Row{
-			{"first row", int64(1)},
-			{"second row", int64(2)},
-			{"third row", int64(3)}},
-	},
-	{
-		"SELECT i + 1 FROM mytable;",
-		[]sql.Row{{int64(2)}, {int64(3)}, {int64(4)}},
-	},
-	{
-		"SELECT -i FROM mytable;",
-		[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
-	},
-	{
-		"SELECT +i FROM mytable;",
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	},
-	{
-		"SELECT + - i FROM mytable;",
-		[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE -i = -2;",
-		[]sql.Row{{int64(2)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i = 2;",
-		[]sql.Row{{int64(2)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i > 2;",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i < 2;",
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i <> 2;",
-		[]sql.Row{{int64(1)}, {int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i IN (1, 3)",
-		[]sql.Row{{int64(1)}, {int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i = 1 OR i = 3",
-		[]sql.Row{{int64(1)}, {int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i >= 2 ORDER BY 1",
-		[]sql.Row{{int64(2)}, {int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i <= 2 ORDER BY 1",
-		[]sql.Row{{int64(1)}, {int64(2)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i > 2",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i < 2",
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i >= 2 OR i = 1 ORDER BY 1",
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	},
-	{
-		"SELECT f32 FROM floattable WHERE f64 = 2.0;",
-		[]sql.Row{{float32(2.0)}},
-	},
-	{
-		"SELECT f32 FROM floattable WHERE f64 < 2.0;",
-		[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}},
-	},
-	{
-		"SELECT f32 FROM floattable WHERE f64 > 2.0;",
-		[]sql.Row{{float32(2.5)}},
-	},
-	{
-		"SELECT f32 FROM floattable WHERE f64 <> 2.0;",
-		[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}, {float32(2.5)}},
-	},
-	{
-		"SELECT f64 FROM floattable WHERE f32 = 2.0;",
-		[]sql.Row{{float64(2.0)}},
-	},
-	{
-		"SELECT f64 FROM floattable WHERE f32 = -1.5;",
-		[]sql.Row{{float64(-1.5)}},
-	},
-	{
-		"SELECT f64 FROM floattable WHERE -f32 = -2.0;",
-		[]sql.Row{{float64(2.0)}},
-	},
-	{
-		"SELECT f64 FROM floattable WHERE f32 < 2.0;",
-		[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}},
-	},
-	{
-		"SELECT f64 FROM floattable WHERE f32 > 2.0;",
-		[]sql.Row{{float64(2.5)}},
-	},
-	{
-		"SELECT f64 FROM floattable WHERE f32 <> 2.0;",
-		[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}, {float64(2.5)}},
-	},
-	{
-		"SELECT f32 FROM floattable ORDER BY f64;",
-		[]sql.Row{{float32(-1.5)}, {float32(-1.0)}, {float32(1.0)}, {float32(1.5)}, {float32(2.0)}, {float32(2.5)}},
-	},
-	{
-		"SELECT i FROM mytable ORDER BY i DESC;",
-		[]sql.Row{{int64(3)}, {int64(2)}, {int64(1)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE 'hello';",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable WHERE NOT 'hello';",
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC;",
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		"SELECT i FROM mytable ORDER BY i LIMIT 1 OFFSET 1;",
-		[]sql.Row{{int64(2)}},
-	},
-	{
-		"SELECT i FROM mytable ORDER BY i LIMIT 1,1;",
-		[]sql.Row{{int64(2)}},
-	},
-	{
-		"SELECT i FROM mytable ORDER BY i LIMIT 3,1;",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable ORDER BY i LIMIT 2,100;",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT i FROM niltable WHERE b IS NULL",
-		[]sql.Row{{int64(2)}, {nil}},
-	},
-	{
-		"SELECT i FROM niltable WHERE b IS NOT NULL",
-		[]sql.Row{{int64(1)}, {nil}, {int64(4)}},
-	},
-	{
-		"SELECT i FROM niltable WHERE b",
-		[]sql.Row{{int64(1)}, {int64(4)}},
-	},
-	{
-		"SELECT i FROM niltable WHERE NOT b",
-		[]sql.Row{{nil}},
-	},
-	{
-		"SELECT i FROM niltable WHERE b IS TRUE",
-		[]sql.Row{{int64(1)}, {int64(4)}},
-	},
-	{
-		"SELECT i FROM niltable WHERE b IS NOT TRUE",
-		[]sql.Row{{int64(2)}, {nil}, {nil}},
-	},
-	{
-		"SELECT f FROM niltable WHERE b IS FALSE",
-		[]sql.Row{{3.0}},
-	},
-	{
-		"SELECT i FROM niltable WHERE b IS NOT FALSE",
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(4)}, {nil}},
-	},
-	{
-		"SELECT COUNT(*) FROM mytable;",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT COUNT(*) FROM mytable LIMIT 1;",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT COUNT(*) AS c FROM mytable;",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT substring(s, 2, 3) FROM mytable",
-		[]sql.Row{{"irs"}, {"eco"}, {"hir"}},
-	},
-	{
-		`SELECT substring("foo", 2, 2)`,
-		[]sql.Row{{"oo"}},
-	},
-	{
-		`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', 2)`,
-		[]sql.Row{
-			{"a.b"},
-		},
-	},
-	{
-		`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', -2)`,
-		[]sql.Row{
-			{"e.f"},
-		},
-	},
-	{
-		`SELECT SUBSTRING_INDEX(SUBSTRING_INDEX('source{d}', '{d}', 1), 'r', -1)`,
-		[]sql.Row{
-			{"ce"},
-		},
-	},
-	{
-		`SELECT SUBSTRING_INDEX(mytable.s, "d", 1) AS s FROM mytable INNER JOIN othertable ON (SUBSTRING_INDEX(mytable.s, "d", 1) = SUBSTRING_INDEX(othertable.s2, "d", 1)) GROUP BY 1 HAVING s = 'secon'`,
-		[]sql.Row{{"secon"}},
-	},
-	{
-		"SELECT YEAR('2007-12-11') FROM mytable",
-		[]sql.Row{{int32(2007)}, {int32(2007)}, {int32(2007)}},
-	},
-	{
-		"SELECT MONTH('2007-12-11') FROM mytable",
-		[]sql.Row{{int32(12)}, {int32(12)}, {int32(12)}},
-	},
-	{
-		"SELECT DAY('2007-12-11') FROM mytable",
-		[]sql.Row{{int32(11)}, {int32(11)}, {int32(11)}},
-	},
-	{
-		"SELECT HOUR('2007-12-11 20:21:22') FROM mytable",
-		[]sql.Row{{int32(20)}, {int32(20)}, {int32(20)}},
-	},
-	{
-		"SELECT MINUTE('2007-12-11 20:21:22') FROM mytable",
-		[]sql.Row{{int32(21)}, {int32(21)}, {int32(21)}},
-	},
-	{
-		"SELECT SECOND('2007-12-11 20:21:22') FROM mytable",
-		[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
-	},
-	{
-		"SELECT DAYOFYEAR('2007-12-11 20:21:22') FROM mytable",
-		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
-	},
-	{
-		"SELECT SECOND('2007-12-11T20:21:22Z') FROM mytable",
-		[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
-	},
-	{
-		"SELECT DAYOFYEAR('2007-12-11') FROM mytable",
-		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
-	},
-	{
-		"SELECT DAYOFYEAR('20071211') FROM mytable",
-		[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
-	},
-	{
-		"SELECT YEARWEEK('0000-01-01')",
-		[]sql.Row{{int32(1)}},
-	},
-	{
-		"SELECT YEARWEEK('9999-12-31')",
-		[]sql.Row{{int32(999952)}},
-	},
-	{
-		"SELECT YEARWEEK('2008-02-20', 1)",
-		[]sql.Row{{int32(200808)}},
-	},
-	{
-		"SELECT YEARWEEK('1987-01-01')",
-		[]sql.Row{{int32(198652)}},
-	},
-	{
-		"SELECT YEARWEEK('1987-01-01', 20), YEARWEEK('1987-01-01', 1), YEARWEEK('1987-01-01', 2), YEARWEEK('1987-01-01', 3), YEARWEEK('1987-01-01', 4), YEARWEEK('1987-01-01', 5), YEARWEEK('1987-01-01', 6), YEARWEEK('1987-01-01', 7)",
-		[]sql.Row{{int32(198653), int32(198701), int32(198652), int32(198701), int32(198653), int32(198652), int32(198653), int32(198652)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i BETWEEN 1 AND 2",
-		[]sql.Row{{int64(1)}, {int64(2)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE i NOT BETWEEN 1 AND 2",
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
-		[]sql.Row{
-			{"third"},
-			{"secon"},
-			{"first"},
-		},
-	},
-	{
-		"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
-		[]sql.Row{
-			{int64(1), int64(1), "third"},
-			{int64(2), int64(2), "second"},
-			{int64(3), int64(3), "first"},
-		},
-	},
-	{
-		"SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
-		[]sql.Row{
-			{"third", int64(1), int64(1)},
-			{"second", int64(2), int64(2)},
-			{ "first", int64(3), int64(3)},
-		},
-	},
-	{
-		"SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
-		[]sql.Row{
-			{int64(1), int64(1), "third"},
-			{int64(2), int64(2), "second"},
-			{int64(3), int64(3), "first"},
-		},
-	},
-	{
-		"SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
-		[]sql.Row{
-			{"third", int64(1), int64(1)},
-			{"second", int64(2), int64(2)},
-			{ "first", int64(3), int64(3)},
-		},
-	},
-	{
-		"SELECT substring(s2, 1), substring(s2, 2), substring(s2, 3) FROM othertable ORDER BY i2",
-		[]sql.Row{
-			{"third", "hird", "ird"},
-			{"second", "econd", "cond"},
-			{"first", "irst", "rst"},
-		},
-	},
-	{
-		`SELECT substring("first", 1), substring("second", 2), substring("third", 3)`,
-		[]sql.Row{
-			{"first", "econd", "ird"},
-		},
-	},
-	{
-		"SELECT substring(s2, -1), substring(s2, -2), substring(s2, -3) FROM othertable ORDER BY i2",
-		[]sql.Row{
-			{"d", "rd", "ird"},
-			{"d", "nd", "ond"},
-			{"t", "st", "rst"},
-		},
-	},
-	{
-		`SELECT substring("first", -1), substring("second", -2), substring("third", -3)`,
-		[]sql.Row{
-			{"t", "nd", "ird"},
-		},
-	},
-	{
-		"SELECT s FROM mytable INNER JOIN othertable " +
-				"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
-		[]sql.Row{
-			{"first row"},
-			{"second row"},
-			{"third row"},
-		},
-	},
-	{
-		`SELECT COUNT(*) AS cnt, fi FROM (
-			SELECT tbl.s AS fi
-			FROM mytable tbl
-		) t
-		GROUP BY fi`,
-		[]sql.Row{
-			{int64(1), "first row"},
-			{int64(1), "second row"},
-			{int64(1), "third row"},
-		},
-	},
-	{
-		`SELECT fi, COUNT(*) FROM (
-			SELECT tbl.s AS fi
-			FROM mytable tbl
-		) t
-		GROUP BY fi
-		ORDER BY COUNT(*) ASC`,
-		[]sql.Row{
-			{"first row", int64(1)},
-			{"second row", int64(1)},
-			{"third row", int64(1)},
-		},
-	},
-	{
-		`SELECT COUNT(*), fi  FROM (
-			SELECT tbl.s AS fi
-			FROM mytable tbl
-		) t
-		GROUP BY fi
-		ORDER BY COUNT(*) ASC`,
-		[]sql.Row{
-			{int64(1), "first row"},
-			{int64(1), "second row"},
-			{int64(1), "third row"},
-		},
-	},
-	{
-		`SELECT COUNT(*) AS cnt, fi FROM (
-			SELECT tbl.s AS fi
-			FROM mytable tbl
-		) t
-		GROUP BY 2`,
-		[]sql.Row{
-			{int64(1), "first row"},
-			{int64(1), "second row"},
-			{int64(1), "third row"},
-		},
-	},
-	{
-		`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY fi`,
-		[]sql.Row{
-			{int64(1), "first row"},
-			{int64(1), "second row"},
-			{int64(1), "third row"},
-		},
-	},
-	{
-		`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY 2`,
-		[]sql.Row{
-			{int64(1), "first row"},
-			{int64(1), "second row"},
-			{int64(1), "third row"},
-		},
-	},
-	{
-		"SELECT CAST(-3 AS UNSIGNED) FROM mytable",
-		[]sql.Row{
-			{uint64(18446744073709551613)},
-			{uint64(18446744073709551613)},
-			{uint64(18446744073709551613)},
-		},
-	},
-	{
-		"SELECT CONVERT(-3, UNSIGNED) FROM mytable",
-		[]sql.Row{
-			{uint64(18446744073709551613)},
-			{uint64(18446744073709551613)},
-			{uint64(18446744073709551613)},
-		},
-	},
-	{
-		"SELECT '3' > 2 FROM tabletest",
-		[]sql.Row{
-			{true},
-			{true},
-			{true},
-		},
-	},
-	{
-		"SELECT s > 2 FROM tabletest",
-		[]sql.Row{
-			{false},
-			{false},
-			{false},
-		},
-	},
-	{
-		"SELECT * FROM tabletest WHERE s > 0",
-		nil,
-	},
-	{
-		"SELECT * FROM tabletest WHERE s = 0",
-		[]sql.Row{
-			{int64(1), "first row"},
-			{int64(2), "second row"},
-			{int64(3), "third row"},
-		},
-	},
-	{
-		"SELECT * FROM tabletest WHERE s = 'first row'",
-		[]sql.Row{
-			{int64(1), "first row"},
-		},
-	},
-	{
-		"SELECT s FROM mytable WHERE i IN (1, 2, 5)",
-		[]sql.Row{
-			{"first row"},
-			{"second row"},
-		},
-	},
-	{
-		"SELECT s FROM mytable WHERE i NOT IN (1, 2, 5)",
-		[]sql.Row{
-			{"third row"},
-		},
-	},
-	{
-		"SELECT 1 + 2",
-		[]sql.Row{
-			{int64(3)},
-		},
-	},
-	{
-		`SELECT i AS foo FROM mytable WHERE foo NOT IN (1, 2, 5)`,
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		`SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
-		[]sql.Row{
-			{int64(1), "first row", int64(1), "first row", "third", int64(1)},
-			{int64(1), "first row", int64(2), "second row", "second", int64(2)},
-			{int64(1), "first row", int64(3), "third row", "first", int64(3)},
-			{int64(2), "second row", int64(1), "first row", "third", int64(1)},
-			{int64(2), "second row", int64(2), "second row", "second", int64(2)},
-			{int64(2), "second row", int64(3), "third row", "first", int64(3)},
-			{int64(3), "third row", int64(1), "first row", "third", int64(1)},
-			{int64(3), "third row", int64(2), "second row", "second", int64(2)},
-			{int64(3), "third row", int64(3), "third row", "first", int64(3)},
-		},
-	},
-	{
-		`SELECT split(s," ") FROM mytable`,
-		[]sql.Row{
-			sql.NewRow([]interface{}{"first", "row"}),
-			sql.NewRow([]interface{}{"second", "row"}),
-			sql.NewRow([]interface{}{"third", "row"}),
-		},
-	},
-	{
-		`SELECT split(s,"s") FROM mytable`,
-		[]sql.Row{
-			sql.NewRow([]interface{}{"fir", "t row"}),
-			sql.NewRow([]interface{}{"", "econd row"}),
-			sql.NewRow([]interface{}{"third row"}),
-		},
-	},
-	{
-		`SELECT SUM(i) FROM mytable`,
-		[]sql.Row{{float64(6)}},
-	},
-	{
-		`SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2`,
-		[]sql.Row{
-			{int64(3), "third row", "first", int64(3)},
-		},
-	},
-	{
-		`SELECT i AS foo FROM mytable ORDER BY i DESC`,
-		[]sql.Row{
-			{int64(3)},
-			{int64(2)},
-			{int64(1)},
-		},
-	},
-	{
-		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY i DESC`,
-		[]sql.Row{
-			{int64(1), int64(3)},
-			{int64(1), int64(2)},
-			{int64(1), int64(1)},
-		},
-	},
-	{
-		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY 2 DESC`,
-		[]sql.Row{
-			{int64(1), int64(3)},
-			{int64(1), int64(2)},
-			{int64(1), int64(1)},
-		},
-	},
-	{
-		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY foo DESC`,
-		[]sql.Row{
-			{int64(1), int64(3)},
-			{int64(1), int64(2)},
-			{int64(1), int64(1)},
-		},
-	},
-	{
-		`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY foo DESC`,
-		[]sql.Row{
-			{int64(1), int64(3)},
-			{int64(1), int64(2)},
-			{int64(1), int64(1)},
-		},
-	},
-	{
-		`SELECT COUNT(*) c, i AS i FROM mytable GROUP BY 2`,
-		[]sql.Row{
-			{int64(1), int64(3)},
-			{int64(1), int64(2)},
-			{int64(1), int64(1)},
-		},
-	},
-	{
-		`SELECT i AS i FROM mytable GROUP BY 1`,
-		[]sql.Row{
-			{int64(3)},
-			{int64(2)},
-			{int64(1)},
-		},
-	},
-	{
-		`SELECT CONCAT("a", "b", "c")`,
-		[]sql.Row{
-			{string("abc")},
-		},
-	},
-	{
-		`SELECT COALESCE(NULL, NULL, NULL, 'example', NULL, 1234567890)`,
-		[]sql.Row{
-			{string("example")},
-		},
-	},
-	{
-		`SELECT COALESCE(NULL, NULL, NULL, COALESCE(NULL, 1234567890))`,
-		[]sql.Row{
-			{int32(1234567890)},
-		},
-	},
-	{
-		"SELECT concat(s, i) FROM mytable",
-		[]sql.Row{
-			{string("first row1")},
-			{string("second row2")},
-			{string("third row3")},
-		},
-	},
-	{
-		"SELECT version()",
-		[]sql.Row{
-			{string("8.0.11")},
-		},
-	},
-	{
-		"SELECT * FROM mytable WHERE 1 > 5",
-		nil,
-	},
-	{
-		"SELECT SUM(i) + 1, i FROM mytable GROUP BY i ORDER BY i",
-		[]sql.Row{
-			{float64(2), int64(1)},
-			{float64(3), int64(2)},
-			{float64(4), int64(3)},
-		},
-	},
-	{
-		"SELECT SUM(i), i FROM mytable GROUP BY i ORDER BY 1+SUM(i) ASC",
-		[]sql.Row{
-			{float64(1), int64(1)},
-			{float64(2), int64(2)},
-			{float64(3), int64(3)},
-		},
-	},
-	{
-		"SELECT i, SUM(i) FROM mytable GROUP BY i ORDER BY SUM(i) DESC",
-		[]sql.Row{
-			{int64(3), float64(3)},
-			{int64(2), float64(2)},
-			{int64(1), float64(1)},
-		},
-	},
-	{
-		`/*!40101 SET NAMES utf8 */`,
-		nil,
-	},
-	{
-		`SHOW DATABASES`,
-		[]sql.Row{{"mydb"}, {"foo"}},
-	},
-	{
-		`SHOW SCHEMAS`,
-		[]sql.Row{{"mydb"}, {"foo"}},
-	},
-	{
-		`SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA`,
-		[]sql.Row{
-			{"mydb", "utf8mb4", "utf8_bin"},
-			{"foo", "utf8mb4", "utf8_bin"},
-		},
-	},
-	{
-		`SELECT s FROM mytable WHERE s LIKE '%d row'`,
-		[]sql.Row{
-			{"second row"},
-			{"third row"},
-		},
-	},
-	{
-		`SELECT SUBSTRING(s, -3, 3) AS s FROM mytable WHERE s LIKE '%d row' GROUP BY 1`,
-		[]sql.Row{
-			{"row"},
-		},
-	},
-	{
-		`SELECT s FROM mytable WHERE s NOT LIKE '%d row'`,
-		[]sql.Row{
-			{"first row"},
-		},
-	},
-	{
-		`SHOW COLUMNS FROM mytable`,
-		[]sql.Row{
-			{"i", "BIGINT", "NO", "", "", ""},
-			{"s", "TEXT", "NO", "", "", ""},
-		},
-	},
-	{
-		`DESCRIBE mytable`,
-		[]sql.Row{
-			{"i", "BIGINT", "NO", "", "", ""},
-			{"s", "TEXT", "NO", "", "", ""},
-		},
-	},
-	{
-		`DESC mytable`,
-		[]sql.Row{
-			{"i", "BIGINT", "NO", "", "", ""},
-			{"s", "TEXT", "NO", "", "", ""},
-		},
-	},
-	{
-		`SHOW COLUMNS FROM one_pk`,
-		[]sql.Row{
-			{"pk", "TINYINT", "NO", "PRI", "", ""},
-			{"c1", "TINYINT", "NO", "", "", ""},
-			{"c2", "TINYINT", "NO", "", "", ""},
-			{"c3", "TINYINT", "NO", "", "", ""},
-			{"c4", "TINYINT", "NO", "", "", ""},
-			{"c5", "TINYINT", "NO", "", "", ""},
-		},
-	},
-	{
-		`DESCRIBE one_pk`,
-		[]sql.Row{
-			{"pk", "TINYINT", "NO", "PRI", "", ""},
-			{"c1", "TINYINT", "NO", "", "", ""},
-			{"c2", "TINYINT", "NO", "", "", ""},
-			{"c3", "TINYINT", "NO", "", "", ""},
-			{"c4", "TINYINT", "NO", "", "", ""},
-			{"c5", "TINYINT", "NO", "", "", ""},
-		},
-	},
-	{
-		`DESC one_pk`,
-		[]sql.Row{
-			{"pk", "TINYINT", "NO", "PRI", "", ""},
-			{"c1", "TINYINT", "NO", "", "", ""},
-			{"c2", "TINYINT", "NO", "", "", ""},
-			{"c3", "TINYINT", "NO", "", "", ""},
-			{"c4", "TINYINT", "NO", "", "", ""},
-			{"c5", "TINYINT", "NO", "", "", ""},
-		},
-	},
-
-	{
-		`SHOW COLUMNS FROM mytable WHERE Field = 'i'`,
-		[]sql.Row{
-			{"i", "BIGINT", "NO", "", "", ""},
-		},
-	},
-	{
-		`SHOW COLUMNS FROM mytable LIKE 'i'`,
-		[]sql.Row{
-			{"i", "BIGINT", "NO", "", "", ""},
-		},
-	},
-	{
-		`SHOW FULL COLUMNS FROM mytable`,
-		[]sql.Row{
-			{"i", "BIGINT", nil, "NO", "", "", "", "", ""},
-			{"s", "TEXT", "utf8_bin", "NO", "", "", "", "", ""},
-		},
-	},
-	{
-		`SHOW FULL COLUMNS FROM one_pk`,
-		[]sql.Row{
-			{"pk", "TINYINT", nil, "NO", "PRI", "", "", "", ""},
-			{"c1", "TINYINT", nil, "NO", "", "", "", "", ""},
-			{"c2", "TINYINT", nil, "NO", "", "", "", "", ""},
-			{"c3", "TINYINT", nil, "NO", "", "", "", "", ""},
-			{"c4", "TINYINT", nil, "NO", "", "", "", "", ""},
-			{"c5", "TINYINT", nil, "NO", "", "", "", "", "column 5"},
-		},
-	},
-	{
-		`SELECT * FROM foo.other_table`,
-		[]sql.Row{
-			{"a", int32(4)},
-			{"b", int32(2)},
-			{"c", int32(0)},
-		},
-	},
-	{
-		`SELECT AVG(23.222000)`,
-		[]sql.Row{
-			{float64(23.222)},
-		},
-	},
-	{
-		`SELECT DATABASE()`,
-		[]sql.Row{
-			{"mydb"},
-		},
-	},
-	{
-		`SHOW VARIABLES`,
-		[]sql.Row{
-			{"auto_increment_increment", int64(1)},
-			{"time_zone", time.Local.String()},
-			{"system_time_zone", time.Local.String()},
-			{"max_allowed_packet", math.MaxInt32},
-			{"sql_mode", ""},
-			{"gtid_mode", int32(0)},
-			{"collation_database", "utf8_bin"},
-			{"ndbinfo_version", ""},
-			{"sql_select_limit", math.MaxInt32},
-			{"transaction_isolation", "READ UNCOMMITTED"},
-			{"version", ""},
-			{"version_comment", ""},
-		},
-	},
-	{
-		`SHOW VARIABLES LIKE 'gtid_mode`,
-		[]sql.Row{
-			{"gtid_mode", int32(0)},
-		},
-	},
-	{
-		`SHOW VARIABLES LIKE 'gtid%`,
-		[]sql.Row{
-			{"gtid_mode", int32(0)},
-		},
-	},
-	{
-		`SHOW GLOBAL VARIABLES LIKE '%mode`,
-		[]sql.Row{
-			{"sql_mode", ""},
-			{"gtid_mode", int32(0)},
-		},
-	},
-	{
-		`SELECT JSON_EXTRACT("foo", "$")`,
-		[]sql.Row{{"foo"}},
-	},
-	{
-		`SELECT JSON_UNQUOTE('"foo"')`,
-		[]sql.Row{{"foo"}},
-	},
-	{
-		`SELECT JSON_UNQUOTE('[1, 2, 3]')`,
-		[]sql.Row{{"[1, 2, 3]"}},
-	},
-	{
-		`SELECT JSON_UNQUOTE('"\\t\\u0032"')`,
-		[]sql.Row{{"\t2"}},
-	},
-	{
-		`SELECT JSON_UNQUOTE('"\t\\u0032"')`,
-		[]sql.Row{{"\t2"}},
-	},
-	{
-		`SELECT CONNECTION_ID()`,
-		[]sql.Row{{uint32(1)}},
-	},
-	{
-		`SHOW CREATE DATABASE mydb`,
-		[]sql.Row{{
-			"mydb",
-			"CREATE DATABASE `mydb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */",
-		}},
-	},
-	{
-		`SELECT -1`,
-		[]sql.Row{{int8(-1)}},
-	},
-	{
-		`
-		SHOW WARNINGS
-		`,
-		nil,
-	},
-	{
-		`SHOW WARNINGS LIMIT 0`,
-		nil,
-	},
-	{
-		`SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
-		nil,
-	},
-	{
-		`SELECT NULL`,
-		[]sql.Row{
-			{nil},
-		},
-	},
-	{
-		`SELECT nullif('abc', NULL)`,
-		[]sql.Row{
-			{"abc"},
-		},
-	},
-	{
-		`SELECT nullif(NULL, NULL)`,
-		[]sql.Row{
-			{sql.Null},
-		},
-	},
-	{
-		`SELECT nullif(NULL, 123)`,
-		[]sql.Row{
-			{nil},
-		},
-	},
-	{
-		`SELECT nullif(123, 123)`,
-		[]sql.Row{
-			{sql.Null},
-		},
-	},
-	{
-		`SELECT nullif(123, 321)`,
-		[]sql.Row{
-			{int8(123)},
-		},
-	},
-	{
-		`SELECT ifnull(123, NULL)`,
-		[]sql.Row{
-			{int8(123)},
-		},
-	},
-	{
-		`SELECT ifnull(NULL, NULL)`,
-		[]sql.Row{
-			{nil},
-		},
-	},
-	{
-		`SELECT ifnull(NULL, 123)`,
-		[]sql.Row{
-			{int8(123)},
-		},
-	},
-	{
-		`SELECT ifnull(123, 123)`,
-		[]sql.Row{
-			{int8(123)},
-		},
-	},
-	{
-		`SELECT ifnull(123, 321)`,
-		[]sql.Row{
-			{int8(123)},
-		},
-	},
-	{
-		"SELECT i FROM mytable WHERE NULL > 10;",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable WHERE NULL IN (10);",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable WHERE NULL IN (NULL, NULL);",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable WHERE NOT NULL NOT IN (NULL);",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable WHERE NOT (NULL) <> 10;",
-		nil,
-	},
-	{
-		"SELECT i FROM mytable WHERE NOT NULL <> NULL;",
-		nil,
-	},
-	{
-		`SELECT round(15728640/1024/1024)`,
-		[]sql.Row{
-			{int64(15)},
-		},
-	},
-	{
-		`SELECT round(15, 1)`,
-		[]sql.Row{
-			{int8(15)},
-		},
-	},
-	{
-		`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'other' END FROM mytable`,
-		[]sql.Row{
-			{"one"},
-			{"two"},
-			{"other"},
-		},
-	},
-	{
-		`SELECT CASE WHEN i > 2 THEN 'more than two' WHEN i < 2 THEN 'less than two' ELSE 'two' END FROM mytable`,
-		[]sql.Row{
-			{"less than two"},
-			{"two"},
-			{"more than two"},
-		},
-	},
-	{
-		`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' END FROM mytable`,
-		[]sql.Row{
-			{"one"},
-			{"two"},
-			{nil},
-		},
-	},
-	{
-		`SHOW COLLATION`,
-		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
-	},
-	{
-		`SHOW COLLATION LIKE 'foo'`,
-		nil,
-	},
-	{
-		`SHOW COLLATION LIKE 'utf8%'`,
-		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
-	},
-	{
-		`SHOW COLLATION WHERE charset = 'foo'`,
-		nil,
-	},
-	{
-		"SHOW COLLATION WHERE `Default` = 'Yes'",
-		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
-	},
-	{
-		"ROLLBACK",
-		nil,
-	},
-	{
-		"SELECT substring(s, 1, 1) FROM mytable ORDER BY substring(s, 1, 1)",
-		[]sql.Row{{"f"}, {"s"}, {"t"}},
-	},
-	{
-		"SELECT substring(s, 1, 1), count(*) FROM mytable GROUP BY substring(s, 1, 1)",
-		[]sql.Row{{"f", int64(1)}, {"s", int64(1)}, {"t", int64(1)}},
-	},
-	{
-		"SELECT SLEEP(0.5)",
-		[]sql.Row{{int(0)}},
-	},
-	{
-		"SELECT TO_BASE64('foo')",
-		[]sql.Row{{string("Zm9v")}},
-	},
-	{
-		"SELECT FROM_BASE64('YmFy')",
-		[]sql.Row{{string("bar")}},
-	},
-	{
-		"SELECT DATE_ADD('2018-05-02', INTERVAL 1 DAY)",
-		[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
-	},
-	{
-		"SELECT DATE_SUB('2018-05-02', INTERVAL 1 DAY)",
-		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
-	},
-	{
-		"SELECT '2018-05-02' + INTERVAL 1 DAY",
-		[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
-	},
-	{
-		"SELECT '2018-05-02' - INTERVAL 1 DAY",
-		[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
-	},
-	{
-		`SELECT i AS i FROM mytable ORDER BY i`,
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	},
-	{
-		`
-		SELECT
-			i,
-			foo
-		FROM (
-			SELECT
-				i,
-				COUNT(s) AS foo
-			FROM mytable
-			GROUP BY i
-		) AS q
-		ORDER BY foo DESC
-		`,
-		[]sql.Row{
-			{int64(1), int64(1)},
-			{int64(2), int64(1)},
-			{int64(3), int64(1)},
-		},
-	},
-	{
-		"SELECT n, COUNT(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
-		[]sql.Row{{int64(1), int64(3)}, {int64(2), int64(3)}},
-	},
-	{
-		"SELECT n, MAX(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
-		[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(2)}},
-	},
-	{
-		"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
-		[]sql.Row{{"secon"}},
-	},
-	{
-		"SELECT s,  i FROM mytable GROUP BY i ORDER BY SUBSTRING(s, 1, 1) DESC",
-		[]sql.Row{
-			{string("third row"), int64(3)},
-			{string("second row"), int64(2)},
-			{string("first row"), int64(1)},
-		},
-	},
-	{
-		"SELECT s, i FROM mytable GROUP BY i HAVING count(*) > 0 ORDER BY SUBSTRING(s, 1, 1) DESC",
-		[]sql.Row{
-			{string("third row"), int64(3)},
-			{string("second row"), int64(2)},
-			{string("first row"), int64(1)},
-		},
-	},
-	{
-		"SELECT CONVERT('9999-12-31 23:59:59', DATETIME)",
-		[]sql.Row{{time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)}},
-	},
-	{
-		"SELECT CONVERT('10000-12-31 23:59:59', DATETIME)",
-		[]sql.Row{{nil}},
-	},
-	{
-		"SELECT '9999-12-31 23:59:59' + INTERVAL 1 DAY",
-		[]sql.Row{{nil}},
-	},
-	{
-		"SELECT DATE_ADD('9999-12-31 23:59:59', INTERVAL 1 DAY)",
-		[]sql.Row{{nil}},
-	},
-	{
-		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) AS date_col) t WHERE t.date_col > '0000-01-01 00:00:00'`,
-		[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
-	},
-	{
-		`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) as date_col) t GROUP BY t.date_col`,
-		[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
-	},
-	{
-		`SELECT i AS foo FROM mytable ORDER BY mytable.i`,
-		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
-	},
-	{
-		`SELECT JSON_EXTRACT('[1, 2, 3]', '$.[0]')`,
-		[]sql.Row{{float64(1)}},
-	},
-	{
-		`SELECT ARRAY_LENGTH(JSON_EXTRACT('[1, 2, 3]', '$'))`,
-		[]sql.Row{{int32(3)}},
-	},
-	{
-		`SELECT ARRAY_LENGTH(JSON_EXTRACT('[{"i":0}, {"i":1, "y":"yyy"}, {"i":2, "x":"xxx"}]', '$.i'))`,
-		[]sql.Row{{int32(3)}},
-	},
-	{
-		`SELECT GREATEST(1, 2, 3, 4)`,
-		[]sql.Row{{int64(4)}},
-	},
-	{
-		`SELECT GREATEST(1, 2, "3", 4)`,
-		[]sql.Row{{float64(4)}},
-	},
-	{
-		`SELECT GREATEST(1, 2, "9", "foo999")`,
-		[]sql.Row{{float64(9)}},
-	},
-	{
-		`SELECT GREATEST("aaa", "bbb", "ccc")`,
-		[]sql.Row{{"ccc"}},
-	},
-	{
-		`SELECT GREATEST(i, s) FROM mytable`,
-		[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
-	},
-	{
-		`SELECT LEAST(1, 2, 3, 4)`,
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		`SELECT LEAST(1, 2, "3", 4)`,
-		[]sql.Row{{float64(1)}},
-	},
-	{
-		`SELECT LEAST(1, 2, "9", "foo999")`,
-		[]sql.Row{{float64(1)}},
-	},
-	{
-		`SELECT LEAST("aaa", "bbb", "ccc")`,
-		[]sql.Row{{"aaa"}},
-	},
-	{
-		`SELECT LEAST(i, s) FROM mytable`,
-		[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
-	},
-	{
-		"SELECT i, i2, s2 FROM mytable LEFT JOIN othertable ON i = i2 - 1",
-		[]sql.Row{
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-			{int64(3), nil, nil},
-		},
-	},
-	{
-		"SELECT i, i2, s2 FROM mytable RIGHT JOIN othertable ON i = i2 - 1",
-		[]sql.Row{
-			{nil, int64(1), "third"},
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-		},
-	},
-	{
-		"SELECT i, i2, s2 FROM mytable LEFT OUTER JOIN othertable ON i = i2 - 1",
-		[]sql.Row{
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-			{int64(3), nil, nil},
-		},
-	},
-	{
-		"SELECT i, i2, s2 FROM mytable RIGHT OUTER JOIN othertable ON i = i2 - 1",
-		[]sql.Row{
-			{nil, int64(1), "third"},
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-		},
-	},
-	{
-		`SELECT CHAR_LENGTH('áé'), LENGTH('àè')`,
-		[]sql.Row{{int32(2), int32(4)}},
-	},
-	{
-		"SELECT i, COUNT(i) AS `COUNT(i)` FROM (SELECT i FROM mytable) t GROUP BY i ORDER BY i, `COUNT(i)` DESC",
-		[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(1)}, {int64(3), int64(1)}},
-	},
-	{
-		"SELECT i FROM mytable WHERE NOT s ORDER BY 1 DESC",
-		[]sql.Row{
-			{int64(3)},
-			{int64(2)},
-			{int64(1)},
-		},
-	},
-	{
-		"SELECT i FROM mytable WHERE NOT(NOT i) ORDER BY 1 DESC",
-		[]sql.Row{
-			{int64(3)},
-			{int64(2)},
-			{int64(1)},
-		},
-	},
-	{
-		`SELECT NOW() - NOW()`,
-		[]sql.Row{{int64(0)}},
-	},
-	{
-		`SELECT NOW() - (NOW() - INTERVAL 1 SECOND)`,
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		`SELECT SUBSTR(SUBSTRING('0123456789ABCDEF', 1, 10), -4)`,
-		[]sql.Row{{"6789"}},
-	},
-	{
-		`SELECT CASE i WHEN 1 THEN i ELSE NULL END FROM mytable`,
-		[]sql.Row{{int64(1)}, {nil}, {nil}},
-	},
-	{
-		`SELECT (NULL+1)`,
-		[]sql.Row{{nil}},
-	},
-	{
-		`SELECT ARRAY_LENGTH(null)`,
-		[]sql.Row{{nil}},
-	},
-	{
-		`SELECT ARRAY_LENGTH("foo")`,
-		[]sql.Row{{nil}},
-	},
-	{
-		`SELECT * FROM mytable WHERE NULL AND i = 3`,
-		nil,
-	},
-	{
-		`SELECT 1 FROM mytable GROUP BY i HAVING i > 1`,
-		[]sql.Row{{int8(1)}, {int8(1)}},
-	},
-	{
-		`SELECT avg(i) FROM mytable GROUP BY i HAVING avg(i) > 1`,
-		[]sql.Row{{float64(2)}, {float64(3)}},
-	},
-	{
-		`SELECT s AS s, COUNT(*) AS count,  AVG(i) AS ` + "`AVG(i)`" + `
-		FROM  (
-			SELECT * FROM mytable
-		) AS expr_qry
-		GROUP BY s
-		HAVING ((AVG(i) > 0))
-		ORDER BY count DESC
-		LIMIT 10000`,
-		[]sql.Row{
-			{"first row", int64(1), float64(1)},
-			{"second row", int64(1), float64(2)},
-			{"third row", int64(1), float64(3)},
-		},
-	},
-	{
-		`SELECT FIRST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		`SELECT LAST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		`SELECT COUNT(DISTINCT t.i) FROM tabletest t, mytable t2`,
-		[]sql.Row{{int64(3)}},
-	},
-	{
-		`SELECT CASE WHEN NULL THEN "yes" ELSE "no" END AS test`,
-		[]sql.Row{{"no"}},
-	},
-	{
-		`SELECT
-			table_schema,
-			table_name,
-			CASE
-				WHEN table_type = 'BASE TABLE' THEN
-					CASE
-						WHEN table_schema = 'mysql'
-							OR table_schema = 'performance_schema' THEN 'SYSTEM TABLE'
-						ELSE 'TABLE'
-					END
-				WHEN table_type = 'TEMPORARY' THEN 'LOCAL_TEMPORARY'
-				ELSE table_type
-			END AS TABLE_TYPE
-		FROM information_schema.tables
-		WHERE table_schema = 'mydb'
-			AND table_name = 'mytable'
-		HAVING table_type IN ('TABLE', 'VIEW')
-		ORDER BY table_type, table_schema, table_name`,
-		[]sql.Row{{"mydb", "mytable", "TABLE"}},
-	},
-	{
-		`SELECT REGEXP_MATCHES("bopbeepbop", "bop")`,
-		[]sql.Row{{[]interface{}{"bop", "bop"}}},
-	},
-	{
-		`SELECT EXPLODE(REGEXP_MATCHES("bopbeepbop", "bop"))`,
-		[]sql.Row{{"bop"}, {"bop"}},
-	},
-	{
-		`SELECT EXPLODE(REGEXP_MATCHES("helloworld", "bop"))`,
-		nil,
-	},
-	{
-		`SELECT EXPLODE(REGEXP_MATCHES("", ""))`,
-		[]sql.Row{{""}},
-	},
-	{
-		`SELECT REGEXP_MATCHES(NULL, "")`,
-		[]sql.Row{{nil}},
-	},
-	{
-		`SELECT REGEXP_MATCHES("", NULL)`,
-		[]sql.Row{{nil}},
-	},
-	{
-		`SELECT REGEXP_MATCHES("", "", NULL)`,
-		[]sql.Row{{nil}},
-	},
-	{
-		"SELECT * FROM newlinetable WHERE s LIKE '%text%'",
-		[]sql.Row{
-			{int64(1), "\nthere is some text IN here"},
-			{int64(2), "there is some\ntext IN here"},
-			{int64(3), "there is some text\nin here"},
-			{int64(4), "there is some text IN here\n"},
-			{int64(5), "there is some text IN here"},
-		},
-	},
-	{
-		`SELECT i FROM mytable WHERE i = (SELECT 1)`,
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		`SELECT i FROM mytable WHERE i IN (SELECT i FROM mytable)`,
-		[]sql.Row{
-			{int64(1)},
-			{int64(2)},
-			{int64(3)},
-		},
-	},
-	{
-		`SELECT i FROM mytable WHERE i NOT IN (SELECT i FROM mytable ORDER BY i ASC LIMIT 2)`,
-		[]sql.Row{
-			{int64(3)},
-		},
-	},
-	{
-		`SELECT (SELECT i FROM mytable ORDER BY i ASC LIMIT 1) AS x`,
-		[]sql.Row{{int64(1)}},
-	},
-	{
-		`SELECT DISTINCT n FROM bigtable ORDER BY t`,
-		[]sql.Row{
-			{int64(1)},
-			{int64(9)},
-			{int64(7)},
-			{int64(3)},
-			{int64(2)},
-			{int64(8)},
-			{int64(6)},
-			{int64(5)},
-			{int64(4)},
-		},
-	},
-	{
-		"SELECT pk,pk1,pk2 FROM one_pk, two_pk ORDER BY 1,2,3",
-		[]sql.Row{
-			{0, 0, 0},
-			{0, 0, 1},
-			{0, 1, 0},
-			{0, 1, 1},
-			{1, 0, 0},
-			{1, 0, 1},
-			{1, 1, 0},
-			{1, 1, 1},
-			{2, 0, 0},
-			{2, 0, 1},
-			{2, 1, 0},
-			{2, 1, 1},
-			{3, 0, 0},
-			{3, 0, 1},
-			{3, 1, 0},
-			{3, 1, 1},
-		},
-	},
-	{
-		"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 AND pk2=1 ORDER BY 1,2",
-		[]sql.Row{
-			{0, 30},
-			{10, 30},
-			{20, 30},
-			{30, 30},
-		},
-	},
-	{
-		"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 OR pk2=1 ORDER BY 1,2",
-		[]sql.Row{
-			{0, 10},
-			{0, 20},
-			{0, 30},
-			{10, 10},
-			{10, 20},
-			{10, 30},
-			{20, 10},
-			{20, 20},
-			{20, 30},
-			{30, 10},
-			{30, 20},
-			{30, 30},
-		},
-	},
-	{
-		"SELECT pk,pk2 FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2",
-		[]sql.Row{
-			{1, 1},
-			{1, 1},
-		},
-	},
-	{
-		"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE pk=0 AND pk1=0 OR pk2=1 ORDER BY 1,2,3",
-		[]sql.Row{
-			{0, 0, 0},
-			{0, 0, 1},
-			{0, 1, 1},
-			{1, 0, 1},
-			{1, 1, 1},
-			{2, 0, 1},
-			{2, 1, 1},
-			{3, 0, 1},
-			{3, 1, 1},
-		},
-	},
-	{
-		"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
-		[]sql.Row{
-			{0, 0, 0},
-			{1, 0, 1},
-			{2, 1, 0},
-			{3, 1, 1},
-		},
-	},
-	{
-		"SELECT one_pk.c5,pk1,pk2 FROM one_pk,two_pk WHERE pk=pk1 ORDER BY 1,2,3",
-		[]sql.Row{
-			{0, 0, 0},
-			{0, 0, 1},
-			{10, 1, 0},
-			{10, 1, 1},
-		},
-	},
-	{
-		"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
-		[]sql.Row{
-			{1, 0, 1},
-		},
-	},
-	{
-		"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk on pk=pk1 ORDER BY 1,2,3",
-		[]sql.Row{
-			{0, 0, 0},
-			{0, 0, 1},
-			{1, 1, 0},
-			{1, 1, 1},
-			{2, nil, nil},
-			{3, nil, nil},
-		},
-	},
+	// {
+	// 	"SELECT i FROM mytable;",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT s,i FROM mytable;",
+	// 	[]sql.Row{
+	// 		{"first row", int64(1)},
+	// 		{"second row", int64(2)},
+	// 		{"third row", int64(3)}},
+	// },
+	// {
+	// 	"SELECT s,i FROM (select i,s FROM mytable) mt;",
+	// 	[]sql.Row{
+	// 		{"first row", int64(1)},
+	// 		{"second row", int64(2)},
+	// 		{"third row", int64(3)}},
+	// },
+	// {
+	// 	"SELECT i + 1 FROM mytable;",
+	// 	[]sql.Row{{int64(2)}, {int64(3)}, {int64(4)}},
+	// },
+	// {
+	// 	"SELECT -i FROM mytable;",
+	// 	[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
+	// },
+	// {
+	// 	"SELECT +i FROM mytable;",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT + - i FROM mytable;",
+	// 	[]sql.Row{{int64(-1)}, {int64(-2)}, {int64(-3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE -i = -2;",
+	// 	[]sql.Row{{int64(2)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i = 2;",
+	// 	[]sql.Row{{int64(2)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i > 2;",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i < 2;",
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i <> 2;",
+	// 	[]sql.Row{{int64(1)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i IN (1, 3)",
+	// 	[]sql.Row{{int64(1)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i = 1 OR i = 3",
+	// 	[]sql.Row{{int64(1)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i >= 2 ORDER BY 1",
+	// 	[]sql.Row{{int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i <= 2 ORDER BY 1",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i > 2",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i < 2",
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i >= 2 OR i = 1 ORDER BY 1",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT f32 FROM floattable WHERE f64 = 2.0;",
+	// 	[]sql.Row{{float32(2.0)}},
+	// },
+	// {
+	// 	"SELECT f32 FROM floattable WHERE f64 < 2.0;",
+	// 	[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}},
+	// },
+	// {
+	// 	"SELECT f32 FROM floattable WHERE f64 > 2.0;",
+	// 	[]sql.Row{{float32(2.5)}},
+	// },
+	// {
+	// 	"SELECT f32 FROM floattable WHERE f64 <> 2.0;",
+	// 	[]sql.Row{{float32(-1.0)}, {float32(-1.5)}, {float32(1.0)}, {float32(1.5)}, {float32(2.5)}},
+	// },
+	// {
+	// 	"SELECT f64 FROM floattable WHERE f32 = 2.0;",
+	// 	[]sql.Row{{float64(2.0)}},
+	// },
+	// {
+	// 	"SELECT f64 FROM floattable WHERE f32 = -1.5;",
+	// 	[]sql.Row{{float64(-1.5)}},
+	// },
+	// {
+	// 	"SELECT f64 FROM floattable WHERE -f32 = -2.0;",
+	// 	[]sql.Row{{float64(2.0)}},
+	// },
+	// {
+	// 	"SELECT f64 FROM floattable WHERE f32 < 2.0;",
+	// 	[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}},
+	// },
+	// {
+	// 	"SELECT f64 FROM floattable WHERE f32 > 2.0;",
+	// 	[]sql.Row{{float64(2.5)}},
+	// },
+	// {
+	// 	"SELECT f64 FROM floattable WHERE f32 <> 2.0;",
+	// 	[]sql.Row{{float64(-1.0)}, {float64(-1.5)}, {float64(1.0)}, {float64(1.5)}, {float64(2.5)}},
+	// },
+	// {
+	// 	"SELECT f32 FROM floattable ORDER BY f64;",
+	// 	[]sql.Row{{float32(-1.5)}, {float32(-1.0)}, {float32(1.0)}, {float32(1.5)}, {float32(2.0)}, {float32(2.5)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable ORDER BY i DESC;",
+	// 	[]sql.Row{{int64(3)}, {int64(2)}, {int64(1)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE 'hello';",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NOT 'hello';",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC;",
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable ORDER BY i LIMIT 1 OFFSET 1;",
+	// 	[]sql.Row{{int64(2)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable ORDER BY i LIMIT 1,1;",
+	// 	[]sql.Row{{int64(2)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable ORDER BY i LIMIT 3,1;",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable ORDER BY i LIMIT 2,100;",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE b IS NULL",
+	// 	[]sql.Row{{int64(2)}, {nil}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE b IS NOT NULL",
+	// 	[]sql.Row{{int64(1)}, {nil}, {int64(4)}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE b",
+	// 	[]sql.Row{{int64(1)}, {int64(4)}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE NOT b",
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE b IS TRUE",
+	// 	[]sql.Row{{int64(1)}, {int64(4)}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE b IS NOT TRUE",
+	// 	[]sql.Row{{int64(2)}, {nil}, {nil}},
+	// },
+	// {
+	// 	"SELECT f FROM niltable WHERE b IS FALSE",
+	// 	[]sql.Row{{3.0}},
+	// },
+	// {
+	// 	"SELECT i FROM niltable WHERE b IS NOT FALSE",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(4)}, {nil}},
+	// },
+	// {
+	// 	"SELECT COUNT(*) FROM mytable;",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT COUNT(*) FROM mytable LIMIT 1;",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT COUNT(*) AS c FROM mytable;",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT substring(s, 2, 3) FROM mytable",
+	// 	[]sql.Row{{"irs"}, {"eco"}, {"hir"}},
+	// },
+	// {
+	// 	`SELECT substring("foo", 2, 2)`,
+	// 	[]sql.Row{{"oo"}},
+	// },
+	// {
+	// 	`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', 2)`,
+	// 	[]sql.Row{
+	// 		{"a.b"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT SUBSTRING_INDEX('a.b.c.d.e.f', '.', -2)`,
+	// 	[]sql.Row{
+	// 		{"e.f"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT SUBSTRING_INDEX(SUBSTRING_INDEX('source{d}', '{d}', 1), 'r', -1)`,
+	// 	[]sql.Row{
+	// 		{"ce"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT SUBSTRING_INDEX(mytable.s, "d", 1) AS s FROM mytable INNER JOIN othertable ON (SUBSTRING_INDEX(mytable.s, "d", 1) = SUBSTRING_INDEX(othertable.s2, "d", 1)) GROUP BY 1 HAVING s = 'secon'`,
+	// 	[]sql.Row{{"secon"}},
+	// },
+	// {
+	// 	"SELECT YEAR('2007-12-11') FROM mytable",
+	// 	[]sql.Row{{int32(2007)}, {int32(2007)}, {int32(2007)}},
+	// },
+	// {
+	// 	"SELECT MONTH('2007-12-11') FROM mytable",
+	// 	[]sql.Row{{int32(12)}, {int32(12)}, {int32(12)}},
+	// },
+	// {
+	// 	"SELECT DAY('2007-12-11') FROM mytable",
+	// 	[]sql.Row{{int32(11)}, {int32(11)}, {int32(11)}},
+	// },
+	// {
+	// 	"SELECT HOUR('2007-12-11 20:21:22') FROM mytable",
+	// 	[]sql.Row{{int32(20)}, {int32(20)}, {int32(20)}},
+	// },
+	// {
+	// 	"SELECT MINUTE('2007-12-11 20:21:22') FROM mytable",
+	// 	[]sql.Row{{int32(21)}, {int32(21)}, {int32(21)}},
+	// },
+	// {
+	// 	"SELECT SECOND('2007-12-11 20:21:22') FROM mytable",
+	// 	[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
+	// },
+	// {
+	// 	"SELECT DAYOFYEAR('2007-12-11 20:21:22') FROM mytable",
+	// 	[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	// },
+	// {
+	// 	"SELECT SECOND('2007-12-11T20:21:22Z') FROM mytable",
+	// 	[]sql.Row{{int32(22)}, {int32(22)}, {int32(22)}},
+	// },
+	// {
+	// 	"SELECT DAYOFYEAR('2007-12-11') FROM mytable",
+	// 	[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	// },
+	// {
+	// 	"SELECT DAYOFYEAR('20071211') FROM mytable",
+	// 	[]sql.Row{{int32(345)}, {int32(345)}, {int32(345)}},
+	// },
+	// {
+	// 	"SELECT YEARWEEK('0000-01-01')",
+	// 	[]sql.Row{{int32(1)}},
+	// },
+	// {
+	// 	"SELECT YEARWEEK('9999-12-31')",
+	// 	[]sql.Row{{int32(999952)}},
+	// },
+	// {
+	// 	"SELECT YEARWEEK('2008-02-20', 1)",
+	// 	[]sql.Row{{int32(200808)}},
+	// },
+	// {
+	// 	"SELECT YEARWEEK('1987-01-01')",
+	// 	[]sql.Row{{int32(198652)}},
+	// },
+	// {
+	// 	"SELECT YEARWEEK('1987-01-01', 20), YEARWEEK('1987-01-01', 1), YEARWEEK('1987-01-01', 2), YEARWEEK('1987-01-01', 3), YEARWEEK('1987-01-01', 4), YEARWEEK('1987-01-01', 5), YEARWEEK('1987-01-01', 6), YEARWEEK('1987-01-01', 7)",
+	// 	[]sql.Row{{int32(198653), int32(198701), int32(198652), int32(198701), int32(198653), int32(198652), int32(198653), int32(198652)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i BETWEEN 1 AND 2",
+	// 	[]sql.Row{{int64(1)}, {int64(2)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE i NOT BETWEEN 1 AND 2",
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
+	// 	[]sql.Row{
+	// 		{"third"},
+	// 		{"secon"},
+	// 		{"first"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+	// 	[]sql.Row{
+	// 		{int64(1), int64(1), "third"},
+	// 		{int64(2), int64(2), "second"},
+	// 		{int64(3), int64(3), "first"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+	// 	[]sql.Row{
+	// 		{"third", int64(1), int64(1)},
+	// 		{"second", int64(2), int64(2)},
+	// 		{ "first", int64(3), int64(3)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
+	// 	[]sql.Row{
+	// 		{int64(1), int64(1), "third"},
+	// 		{int64(2), int64(2), "second"},
+	// 		{int64(3), int64(3), "first"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
+	// 	[]sql.Row{
+	// 		{"third", int64(1), int64(1)},
+	// 		{"second", int64(2), int64(2)},
+	// 		{ "first", int64(3), int64(3)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT substring(s2, 1), substring(s2, 2), substring(s2, 3) FROM othertable ORDER BY i2",
+	// 	[]sql.Row{
+	// 		{"third", "hird", "ird"},
+	// 		{"second", "econd", "cond"},
+	// 		{"first", "irst", "rst"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT substring("first", 1), substring("second", 2), substring("third", 3)`,
+	// 	[]sql.Row{
+	// 		{"first", "econd", "ird"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT substring(s2, -1), substring(s2, -2), substring(s2, -3) FROM othertable ORDER BY i2",
+	// 	[]sql.Row{
+	// 		{"d", "rd", "ird"},
+	// 		{"d", "nd", "ond"},
+	// 		{"t", "st", "rst"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT substring("first", -1), substring("second", -2), substring("third", -3)`,
+	// 	[]sql.Row{
+	// 		{"t", "nd", "ird"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s FROM mytable INNER JOIN othertable " +
+	// 			"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
+	// 	[]sql.Row{
+	// 		{"first row"},
+	// 		{"second row"},
+	// 		{"third row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) AS cnt, fi FROM (
+	// 		SELECT tbl.s AS fi
+	// 		FROM mytable tbl
+	// 	) t
+	// 	GROUP BY fi`,
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 		{int64(1), "second row"},
+	// 		{int64(1), "third row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT fi, COUNT(*) FROM (
+	// 		SELECT tbl.s AS fi
+	// 		FROM mytable tbl
+	// 	) t
+	// 	GROUP BY fi
+	// 	ORDER BY COUNT(*) ASC`,
+	// 	[]sql.Row{
+	// 		{"first row", int64(1)},
+	// 		{"second row", int64(1)},
+	// 		{"third row", int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*), fi  FROM (
+	// 		SELECT tbl.s AS fi
+	// 		FROM mytable tbl
+	// 	) t
+	// 	GROUP BY fi
+	// 	ORDER BY COUNT(*) ASC`,
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 		{int64(1), "second row"},
+	// 		{int64(1), "third row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) AS cnt, fi FROM (
+	// 		SELECT tbl.s AS fi
+	// 		FROM mytable tbl
+	// 	) t
+	// 	GROUP BY 2`,
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 		{int64(1), "second row"},
+	// 		{int64(1), "third row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY fi`,
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 		{int64(1), "second row"},
+	// 		{int64(1), "third row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) AS cnt, s AS fi FROM mytable GROUP BY 2`,
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 		{int64(1), "second row"},
+	// 		{int64(1), "third row"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT CAST(-3 AS UNSIGNED) FROM mytable",
+	// 	[]sql.Row{
+	// 		{uint64(18446744073709551613)},
+	// 		{uint64(18446744073709551613)},
+	// 		{uint64(18446744073709551613)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT CONVERT(-3, UNSIGNED) FROM mytable",
+	// 	[]sql.Row{
+	// 		{uint64(18446744073709551613)},
+	// 		{uint64(18446744073709551613)},
+	// 		{uint64(18446744073709551613)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT '3' > 2 FROM tabletest",
+	// 	[]sql.Row{
+	// 		{true},
+	// 		{true},
+	// 		{true},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s > 2 FROM tabletest",
+	// 	[]sql.Row{
+	// 		{false},
+	// 		{false},
+	// 		{false},
+	// 	},
+	// },
+	// {
+	// 	"SELECT * FROM tabletest WHERE s > 0",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT * FROM tabletest WHERE s = 0",
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 		{int64(2), "second row"},
+	// 		{int64(3), "third row"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT * FROM tabletest WHERE s = 'first row'",
+	// 	[]sql.Row{
+	// 		{int64(1), "first row"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s FROM mytable WHERE i IN (1, 2, 5)",
+	// 	[]sql.Row{
+	// 		{"first row"},
+	// 		{"second row"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s FROM mytable WHERE i NOT IN (1, 2, 5)",
+	// 	[]sql.Row{
+	// 		{"third row"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT 1 + 2",
+	// 	[]sql.Row{
+	// 		{int64(3)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT i AS foo FROM mytable WHERE foo NOT IN (1, 2, 5)`,
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	`SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
+	// 	[]sql.Row{
+	// 		{int64(1), "first row", int64(1), "first row", "third", int64(1)},
+	// 		{int64(1), "first row", int64(2), "second row", "second", int64(2)},
+	// 		{int64(1), "first row", int64(3), "third row", "first", int64(3)},
+	// 		{int64(2), "second row", int64(1), "first row", "third", int64(1)},
+	// 		{int64(2), "second row", int64(2), "second row", "second", int64(2)},
+	// 		{int64(2), "second row", int64(3), "third row", "first", int64(3)},
+	// 		{int64(3), "third row", int64(1), "first row", "third", int64(1)},
+	// 		{int64(3), "third row", int64(2), "second row", "second", int64(2)},
+	// 		{int64(3), "third row", int64(3), "third row", "first", int64(3)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT split(s," ") FROM mytable`,
+	// 	[]sql.Row{
+	// 		sql.NewRow([]interface{}{"first", "row"}),
+	// 		sql.NewRow([]interface{}{"second", "row"}),
+	// 		sql.NewRow([]interface{}{"third", "row"}),
+	// 	},
+	// },
+	// {
+	// 	`SELECT split(s,"s") FROM mytable`,
+	// 	[]sql.Row{
+	// 		sql.NewRow([]interface{}{"fir", "t row"}),
+	// 		sql.NewRow([]interface{}{"", "econd row"}),
+	// 		sql.NewRow([]interface{}{"third row"}),
+	// 	},
+	// },
+	// {
+	// 	`SELECT SUM(i) FROM mytable`,
+	// 	[]sql.Row{{float64(6)}},
+	// },
+	// {
+	// 	`SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2`,
+	// 	[]sql.Row{
+	// 		{int64(3), "third row", "first", int64(3)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT i AS foo FROM mytable ORDER BY i DESC`,
+	// 	[]sql.Row{
+	// 		{int64(3)},
+	// 		{int64(2)},
+	// 		{int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY i DESC`,
+	// 	[]sql.Row{
+	// 		{int64(1), int64(3)},
+	// 		{int64(1), int64(2)},
+	// 		{int64(1), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY 2 DESC`,
+	// 	[]sql.Row{
+	// 		{int64(1), int64(3)},
+	// 		{int64(1), int64(2)},
+	// 		{int64(1), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY i ORDER BY foo DESC`,
+	// 	[]sql.Row{
+	// 		{int64(1), int64(3)},
+	// 		{int64(1), int64(2)},
+	// 		{int64(1), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) c, i AS foo FROM mytable GROUP BY 2 ORDER BY foo DESC`,
+	// 	[]sql.Row{
+	// 		{int64(1), int64(3)},
+	// 		{int64(1), int64(2)},
+	// 		{int64(1), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COUNT(*) c, i AS i FROM mytable GROUP BY 2`,
+	// 	[]sql.Row{
+	// 		{int64(1), int64(3)},
+	// 		{int64(1), int64(2)},
+	// 		{int64(1), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT i AS i FROM mytable GROUP BY 1`,
+	// 	[]sql.Row{
+	// 		{int64(3)},
+	// 		{int64(2)},
+	// 		{int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT CONCAT("a", "b", "c")`,
+	// 	[]sql.Row{
+	// 		{string("abc")},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COALESCE(NULL, NULL, NULL, 'example', NULL, 1234567890)`,
+	// 	[]sql.Row{
+	// 		{string("example")},
+	// 	},
+	// },
+	// {
+	// 	`SELECT COALESCE(NULL, NULL, NULL, COALESCE(NULL, 1234567890))`,
+	// 	[]sql.Row{
+	// 		{int32(1234567890)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT concat(s, i) FROM mytable",
+	// 	[]sql.Row{
+	// 		{string("first row1")},
+	// 		{string("second row2")},
+	// 		{string("third row3")},
+	// 	},
+	// },
+	// {
+	// 	"SELECT version()",
+	// 	[]sql.Row{
+	// 		{string("8.0.11")},
+	// 	},
+	// },
+	// {
+	// 	"SELECT * FROM mytable WHERE 1 > 5",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT SUM(i) + 1, i FROM mytable GROUP BY i ORDER BY i",
+	// 	[]sql.Row{
+	// 		{float64(2), int64(1)},
+	// 		{float64(3), int64(2)},
+	// 		{float64(4), int64(3)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT SUM(i), i FROM mytable GROUP BY i ORDER BY 1+SUM(i) ASC",
+	// 	[]sql.Row{
+	// 		{float64(1), int64(1)},
+	// 		{float64(2), int64(2)},
+	// 		{float64(3), int64(3)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i, SUM(i) FROM mytable GROUP BY i ORDER BY SUM(i) DESC",
+	// 	[]sql.Row{
+	// 		{int64(3), float64(3)},
+	// 		{int64(2), float64(2)},
+	// 		{int64(1), float64(1)},
+	// 	},
+	// },
+	// {
+	// 	`/*!40101 SET NAMES utf8 */`,
+	// 	nil,
+	// },
+	// {
+	// 	`SHOW DATABASES`,
+	// 	[]sql.Row{{"mydb"}, {"foo"}},
+	// },
+	// {
+	// 	`SHOW SCHEMAS`,
+	// 	[]sql.Row{{"mydb"}, {"foo"}},
+	// },
+	// {
+	// 	`SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA`,
+	// 	[]sql.Row{
+	// 		{"mydb", "utf8mb4", "utf8_bin"},
+	// 		{"foo", "utf8mb4", "utf8_bin"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT s FROM mytable WHERE s LIKE '%d row'`,
+	// 	[]sql.Row{
+	// 		{"second row"},
+	// 		{"third row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT SUBSTRING(s, -3, 3) AS s FROM mytable WHERE s LIKE '%d row' GROUP BY 1`,
+	// 	[]sql.Row{
+	// 		{"row"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT s FROM mytable WHERE s NOT LIKE '%d row'`,
+	// 	[]sql.Row{
+	// 		{"first row"},
+	// 	},
+	// },
+	// {
+	// 	`SHOW COLUMNS FROM mytable`,
+	// 	[]sql.Row{
+	// 		{"i", "BIGINT", "NO", "", "", ""},
+	// 		{"s", "TEXT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`DESCRIBE mytable`,
+	// 	[]sql.Row{
+	// 		{"i", "BIGINT", "NO", "", "", ""},
+	// 		{"s", "TEXT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`DESC mytable`,
+	// 	[]sql.Row{
+	// 		{"i", "BIGINT", "NO", "", "", ""},
+	// 		{"s", "TEXT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`SHOW COLUMNS FROM one_pk`,
+	// 	[]sql.Row{
+	// 		{"pk", "TINYINT", "NO", "PRI", "", ""},
+	// 		{"c1", "TINYINT", "NO", "", "", ""},
+	// 		{"c2", "TINYINT", "NO", "", "", ""},
+	// 		{"c3", "TINYINT", "NO", "", "", ""},
+	// 		{"c4", "TINYINT", "NO", "", "", ""},
+	// 		{"c5", "TINYINT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`DESCRIBE one_pk`,
+	// 	[]sql.Row{
+	// 		{"pk", "TINYINT", "NO", "PRI", "", ""},
+	// 		{"c1", "TINYINT", "NO", "", "", ""},
+	// 		{"c2", "TINYINT", "NO", "", "", ""},
+	// 		{"c3", "TINYINT", "NO", "", "", ""},
+	// 		{"c4", "TINYINT", "NO", "", "", ""},
+	// 		{"c5", "TINYINT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`DESC one_pk`,
+	// 	[]sql.Row{
+	// 		{"pk", "TINYINT", "NO", "PRI", "", ""},
+	// 		{"c1", "TINYINT", "NO", "", "", ""},
+	// 		{"c2", "TINYINT", "NO", "", "", ""},
+	// 		{"c3", "TINYINT", "NO", "", "", ""},
+	// 		{"c4", "TINYINT", "NO", "", "", ""},
+	// 		{"c5", "TINYINT", "NO", "", "", ""},
+	// 	},
+	// },
+	//
+	// {
+	// 	`SHOW COLUMNS FROM mytable WHERE Field = 'i'`,
+	// 	[]sql.Row{
+	// 		{"i", "BIGINT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`SHOW COLUMNS FROM mytable LIKE 'i'`,
+	// 	[]sql.Row{
+	// 		{"i", "BIGINT", "NO", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`SHOW FULL COLUMNS FROM mytable`,
+	// 	[]sql.Row{
+	// 		{"i", "BIGINT", nil, "NO", "", "", "", "", ""},
+	// 		{"s", "TEXT", "utf8_bin", "NO", "", "", "", "", ""},
+	// 	},
+	// },
+	// {
+	// 	`SHOW FULL COLUMNS FROM one_pk`,
+	// 	[]sql.Row{
+	// 		{"pk", "TINYINT", nil, "NO", "PRI", "", "", "", ""},
+	// 		{"c1", "TINYINT", nil, "NO", "", "", "", "", ""},
+	// 		{"c2", "TINYINT", nil, "NO", "", "", "", "", ""},
+	// 		{"c3", "TINYINT", nil, "NO", "", "", "", "", ""},
+	// 		{"c4", "TINYINT", nil, "NO", "", "", "", "", ""},
+	// 		{"c5", "TINYINT", nil, "NO", "", "", "", "", "column 5"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT * FROM foo.other_table`,
+	// 	[]sql.Row{
+	// 		{"a", int32(4)},
+	// 		{"b", int32(2)},
+	// 		{"c", int32(0)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT AVG(23.222000)`,
+	// 	[]sql.Row{
+	// 		{float64(23.222)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT DATABASE()`,
+	// 	[]sql.Row{
+	// 		{"mydb"},
+	// 	},
+	// },
+	// {
+	// 	`SHOW VARIABLES`,
+	// 	[]sql.Row{
+	// 		{"auto_increment_increment", int64(1)},
+	// 		{"time_zone", time.Local.String()},
+	// 		{"system_time_zone", time.Local.String()},
+	// 		{"max_allowed_packet", math.MaxInt32},
+	// 		{"sql_mode", ""},
+	// 		{"gtid_mode", int32(0)},
+	// 		{"collation_database", "utf8_bin"},
+	// 		{"ndbinfo_version", ""},
+	// 		{"sql_select_limit", math.MaxInt32},
+	// 		{"transaction_isolation", "READ UNCOMMITTED"},
+	// 		{"version", ""},
+	// 		{"version_comment", ""},
+	// 	},
+	// },
+	// {
+	// 	`SHOW VARIABLES LIKE 'gtid_mode`,
+	// 	[]sql.Row{
+	// 		{"gtid_mode", int32(0)},
+	// 	},
+	// },
+	// {
+	// 	`SHOW VARIABLES LIKE 'gtid%`,
+	// 	[]sql.Row{
+	// 		{"gtid_mode", int32(0)},
+	// 	},
+	// },
+	// {
+	// 	`SHOW GLOBAL VARIABLES LIKE '%mode`,
+	// 	[]sql.Row{
+	// 		{"sql_mode", ""},
+	// 		{"gtid_mode", int32(0)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT JSON_EXTRACT("foo", "$")`,
+	// 	[]sql.Row{{"foo"}},
+	// },
+	// {
+	// 	`SELECT JSON_UNQUOTE('"foo"')`,
+	// 	[]sql.Row{{"foo"}},
+	// },
+	// {
+	// 	`SELECT JSON_UNQUOTE('[1, 2, 3]')`,
+	// 	[]sql.Row{{"[1, 2, 3]"}},
+	// },
+	// {
+	// 	`SELECT JSON_UNQUOTE('"\\t\\u0032"')`,
+	// 	[]sql.Row{{"\t2"}},
+	// },
+	// {
+	// 	`SELECT JSON_UNQUOTE('"\t\\u0032"')`,
+	// 	[]sql.Row{{"\t2"}},
+	// },
+	// {
+	// 	`SELECT CONNECTION_ID()`,
+	// 	[]sql.Row{{uint32(1)}},
+	// },
+	// {
+	// 	`SHOW CREATE DATABASE mydb`,
+	// 	[]sql.Row{{
+	// 		"mydb",
+	// 		"CREATE DATABASE `mydb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */",
+	// 	}},
+	// },
+	// {
+	// 	`SELECT -1`,
+	// 	[]sql.Row{{int8(-1)}},
+	// },
+	// {
+	// 	`
+	// 	SHOW WARNINGS
+	// 	`,
+	// 	nil,
+	// },
+	// {
+	// 	`SHOW WARNINGS LIMIT 0`,
+	// 	nil,
+	// },
+	// {
+	// 	`SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
+	// 	nil,
+	// },
+	// {
+	// 	`SELECT NULL`,
+	// 	[]sql.Row{
+	// 		{nil},
+	// 	},
+	// },
+	// {
+	// 	`SELECT nullif('abc', NULL)`,
+	// 	[]sql.Row{
+	// 		{"abc"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT nullif(NULL, NULL)`,
+	// 	[]sql.Row{
+	// 		{sql.Null},
+	// 	},
+	// },
+	// {
+	// 	`SELECT nullif(NULL, 123)`,
+	// 	[]sql.Row{
+	// 		{nil},
+	// 	},
+	// },
+	// {
+	// 	`SELECT nullif(123, 123)`,
+	// 	[]sql.Row{
+	// 		{sql.Null},
+	// 	},
+	// },
+	// {
+	// 	`SELECT nullif(123, 321)`,
+	// 	[]sql.Row{
+	// 		{int8(123)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT ifnull(123, NULL)`,
+	// 	[]sql.Row{
+	// 		{int8(123)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT ifnull(NULL, NULL)`,
+	// 	[]sql.Row{
+	// 		{nil},
+	// 	},
+	// },
+	// {
+	// 	`SELECT ifnull(NULL, 123)`,
+	// 	[]sql.Row{
+	// 		{int8(123)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT ifnull(123, 123)`,
+	// 	[]sql.Row{
+	// 		{int8(123)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT ifnull(123, 321)`,
+	// 	[]sql.Row{
+	// 		{int8(123)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NULL > 10;",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NULL IN (10);",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NULL IN (NULL, NULL);",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NOT NULL NOT IN (NULL);",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NOT (NULL) <> 10;",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NOT NULL <> NULL;",
+	// 	nil,
+	// },
+	// {
+	// 	`SELECT round(15728640/1024/1024)`,
+	// 	[]sql.Row{
+	// 		{int64(15)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT round(15, 1)`,
+	// 	[]sql.Row{
+	// 		{int8(15)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'other' END FROM mytable`,
+	// 	[]sql.Row{
+	// 		{"one"},
+	// 		{"two"},
+	// 		{"other"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT CASE WHEN i > 2 THEN 'more than two' WHEN i < 2 THEN 'less than two' ELSE 'two' END FROM mytable`,
+	// 	[]sql.Row{
+	// 		{"less than two"},
+	// 		{"two"},
+	// 		{"more than two"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT CASE i WHEN 1 THEN 'one' WHEN 2 THEN 'two' END FROM mytable`,
+	// 	[]sql.Row{
+	// 		{"one"},
+	// 		{"two"},
+	// 		{nil},
+	// 	},
+	// },
+	// {
+	// 	`SHOW COLLATION`,
+	// 	[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
+	// },
+	// {
+	// 	`SHOW COLLATION LIKE 'foo'`,
+	// 	nil,
+	// },
+	// {
+	// 	`SHOW COLLATION LIKE 'utf8%'`,
+	// 	[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
+	// },
+	// {
+	// 	`SHOW COLLATION WHERE charset = 'foo'`,
+	// 	nil,
+	// },
+	// {
+	// 	"SHOW COLLATION WHERE `Default` = 'Yes'",
+	// 	[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1)}},
+	// },
+	// {
+	// 	"ROLLBACK",
+	// 	nil,
+	// },
+	// {
+	// 	"SELECT substring(s, 1, 1) FROM mytable ORDER BY substring(s, 1, 1)",
+	// 	[]sql.Row{{"f"}, {"s"}, {"t"}},
+	// },
+	// {
+	// 	"SELECT substring(s, 1, 1), count(*) FROM mytable GROUP BY substring(s, 1, 1)",
+	// 	[]sql.Row{{"f", int64(1)}, {"s", int64(1)}, {"t", int64(1)}},
+	// },
+	// {
+	// 	"SELECT SLEEP(0.5)",
+	// 	[]sql.Row{{int(0)}},
+	// },
+	// {
+	// 	"SELECT TO_BASE64('foo')",
+	// 	[]sql.Row{{string("Zm9v")}},
+	// },
+	// {
+	// 	"SELECT FROM_BASE64('YmFy')",
+	// 	[]sql.Row{{string("bar")}},
+	// },
+	// {
+	// 	"SELECT DATE_ADD('2018-05-02', INTERVAL 1 DAY)",
+	// 	[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+	// },
+	// {
+	// 	"SELECT DATE_SUB('2018-05-02', INTERVAL 1 DAY)",
+	// 	[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+	// },
+	// {
+	// 	"SELECT '2018-05-02' + INTERVAL 1 DAY",
+	// 	[]sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+	// },
+	// {
+	// 	"SELECT '2018-05-02' - INTERVAL 1 DAY",
+	// 	[]sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+	// },
+	// {
+	// 	`SELECT i AS i FROM mytable ORDER BY i`,
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	`
+	// 	SELECT
+	// 		i,
+	// 		foo
+	// 	FROM (
+	// 		SELECT
+	// 			i,
+	// 			COUNT(s) AS foo
+	// 		FROM mytable
+	// 		GROUP BY i
+	// 	) AS q
+	// 	ORDER BY foo DESC
+	// 	`,
+	// 	[]sql.Row{
+	// 		{int64(1), int64(1)},
+	// 		{int64(2), int64(1)},
+	// 		{int64(3), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT n, COUNT(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
+	// 	[]sql.Row{{int64(1), int64(3)}, {int64(2), int64(3)}},
+	// },
+	// {
+	// 	"SELECT n, MAX(n) FROM bigtable GROUP BY n HAVING COUNT(n) > 2",
+	// 	[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(2)}},
+	// },
+	// {
+	// 	"SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1 HAVING s = \"secon\"",
+	// 	[]sql.Row{{"secon"}},
+	// },
+	// {
+	// 	"SELECT s,  i FROM mytable GROUP BY i ORDER BY SUBSTRING(s, 1, 1) DESC",
+	// 	[]sql.Row{
+	// 		{string("third row"), int64(3)},
+	// 		{string("second row"), int64(2)},
+	// 		{string("first row"), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT s, i FROM mytable GROUP BY i HAVING count(*) > 0 ORDER BY SUBSTRING(s, 1, 1) DESC",
+	// 	[]sql.Row{
+	// 		{string("third row"), int64(3)},
+	// 		{string("second row"), int64(2)},
+	// 		{string("first row"), int64(1)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT CONVERT('9999-12-31 23:59:59', DATETIME)",
+	// 	[]sql.Row{{time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)}},
+	// },
+	// {
+	// 	"SELECT CONVERT('10000-12-31 23:59:59', DATETIME)",
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	"SELECT '9999-12-31 23:59:59' + INTERVAL 1 DAY",
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	"SELECT DATE_ADD('9999-12-31 23:59:59', INTERVAL 1 DAY)",
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) AS date_col) t WHERE t.date_col > '0000-01-01 00:00:00'`,
+	// 	[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
+	// },
+	// {
+	// 	`SELECT t.date_col FROM (SELECT CONVERT('2019-06-06 00:00:00', DATETIME) as date_col) t GROUP BY t.date_col`,
+	// 	[]sql.Row{{time.Date(2019, time.June, 6, 0, 0, 0, 0, time.UTC)}},
+	// },
+	// {
+	// 	`SELECT i AS foo FROM mytable ORDER BY mytable.i`,
+	// 	[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	// },
+	// {
+	// 	`SELECT JSON_EXTRACT('[1, 2, 3]', '$.[0]')`,
+	// 	[]sql.Row{{float64(1)}},
+	// },
+	// {
+	// 	`SELECT ARRAY_LENGTH(JSON_EXTRACT('[1, 2, 3]', '$'))`,
+	// 	[]sql.Row{{int32(3)}},
+	// },
+	// {
+	// 	`SELECT ARRAY_LENGTH(JSON_EXTRACT('[{"i":0}, {"i":1, "y":"yyy"}, {"i":2, "x":"xxx"}]', '$.i'))`,
+	// 	[]sql.Row{{int32(3)}},
+	// },
+	// {
+	// 	`SELECT GREATEST(1, 2, 3, 4)`,
+	// 	[]sql.Row{{int64(4)}},
+	// },
+	// {
+	// 	`SELECT GREATEST(1, 2, "3", 4)`,
+	// 	[]sql.Row{{float64(4)}},
+	// },
+	// {
+	// 	`SELECT GREATEST(1, 2, "9", "foo999")`,
+	// 	[]sql.Row{{float64(9)}},
+	// },
+	// {
+	// 	`SELECT GREATEST("aaa", "bbb", "ccc")`,
+	// 	[]sql.Row{{"ccc"}},
+	// },
+	// {
+	// 	`SELECT GREATEST(i, s) FROM mytable`,
+	// 	[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
+	// },
+	// {
+	// 	`SELECT LEAST(1, 2, 3, 4)`,
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	`SELECT LEAST(1, 2, "3", 4)`,
+	// 	[]sql.Row{{float64(1)}},
+	// },
+	// {
+	// 	`SELECT LEAST(1, 2, "9", "foo999")`,
+	// 	[]sql.Row{{float64(1)}},
+	// },
+	// {
+	// 	`SELECT LEAST("aaa", "bbb", "ccc")`,
+	// 	[]sql.Row{{"aaa"}},
+	// },
+	// {
+	// 	`SELECT LEAST(i, s) FROM mytable`,
+	// 	[]sql.Row{{float64(1)}, {float64(2)}, {float64(3)}},
+	// },
+	// {
+	// 	"SELECT i, i2, s2 FROM mytable LEFT JOIN othertable ON i = i2 - 1",
+	// 	[]sql.Row{
+	// 		{int64(1), int64(2), "second"},
+	// 		{int64(2), int64(3), "first"},
+	// 		{int64(3), nil, nil},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i, i2, s2 FROM mytable RIGHT JOIN othertable ON i = i2 - 1",
+	// 	[]sql.Row{
+	// 		{nil, int64(1), "third"},
+	// 		{int64(1), int64(2), "second"},
+	// 		{int64(2), int64(3), "first"},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i, i2, s2 FROM mytable LEFT OUTER JOIN othertable ON i = i2 - 1",
+	// 	[]sql.Row{
+	// 		{int64(1), int64(2), "second"},
+	// 		{int64(2), int64(3), "first"},
+	// 		{int64(3), nil, nil},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i, i2, s2 FROM mytable RIGHT OUTER JOIN othertable ON i = i2 - 1",
+	// 	[]sql.Row{
+	// 		{nil, int64(1), "third"},
+	// 		{int64(1), int64(2), "second"},
+	// 		{int64(2), int64(3), "first"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT CHAR_LENGTH('áé'), LENGTH('àè')`,
+	// 	[]sql.Row{{int32(2), int32(4)}},
+	// },
+	// {
+	// 	"SELECT i, COUNT(i) AS `COUNT(i)` FROM (SELECT i FROM mytable) t GROUP BY i ORDER BY i, `COUNT(i)` DESC",
+	// 	[]sql.Row{{int64(1), int64(1)}, {int64(2), int64(1)}, {int64(3), int64(1)}},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NOT s ORDER BY 1 DESC",
+	// 	[]sql.Row{
+	// 		{int64(3)},
+	// 		{int64(2)},
+	// 		{int64(1)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT i FROM mytable WHERE NOT(NOT i) ORDER BY 1 DESC",
+	// 	[]sql.Row{
+	// 		{int64(3)},
+	// 		{int64(2)},
+	// 		{int64(1)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT NOW() - NOW()`,
+	// 	[]sql.Row{{int64(0)}},
+	// },
+	// {
+	// 	`SELECT NOW() - (NOW() - INTERVAL 1 SECOND)`,
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	`SELECT SUBSTR(SUBSTRING('0123456789ABCDEF', 1, 10), -4)`,
+	// 	[]sql.Row{{"6789"}},
+	// },
+	// {
+	// 	`SELECT CASE i WHEN 1 THEN i ELSE NULL END FROM mytable`,
+	// 	[]sql.Row{{int64(1)}, {nil}, {nil}},
+	// },
+	// {
+	// 	`SELECT (NULL+1)`,
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	`SELECT ARRAY_LENGTH(null)`,
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	`SELECT ARRAY_LENGTH("foo")`,
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	`SELECT * FROM mytable WHERE NULL AND i = 3`,
+	// 	nil,
+	// },
+	// {
+	// 	`SELECT 1 FROM mytable GROUP BY i HAVING i > 1`,
+	// 	[]sql.Row{{int8(1)}, {int8(1)}},
+	// },
+	// {
+	// 	`SELECT avg(i) FROM mytable GROUP BY i HAVING avg(i) > 1`,
+	// 	[]sql.Row{{float64(2)}, {float64(3)}},
+	// },
+	// {
+	// 	`SELECT s AS s, COUNT(*) AS count,  AVG(i) AS ` + "`AVG(i)`" + `
+	// 	FROM  (
+	// 		SELECT * FROM mytable
+	// 	) AS expr_qry
+	// 	GROUP BY s
+	// 	HAVING ((AVG(i) > 0))
+	// 	ORDER BY count DESC
+	// 	LIMIT 10000`,
+	// 	[]sql.Row{
+	// 		{"first row", int64(1), float64(1)},
+	// 		{"second row", int64(1), float64(2)},
+	// 		{"third row", int64(1), float64(3)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT FIRST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	`SELECT LAST(i) FROM (SELECT i FROM mytable ORDER BY i) t`,
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	`SELECT COUNT(DISTINCT t.i) FROM tabletest t, mytable t2`,
+	// 	[]sql.Row{{int64(3)}},
+	// },
+	// {
+	// 	`SELECT CASE WHEN NULL THEN "yes" ELSE "no" END AS test`,
+	// 	[]sql.Row{{"no"}},
+	// },
+	// {
+	// 	`SELECT
+	// 		table_schema,
+	// 		table_name,
+	// 		CASE
+	// 			WHEN table_type = 'BASE TABLE' THEN
+	// 				CASE
+	// 					WHEN table_schema = 'mysql'
+	// 						OR table_schema = 'performance_schema' THEN 'SYSTEM TABLE'
+	// 					ELSE 'TABLE'
+	// 				END
+	// 			WHEN table_type = 'TEMPORARY' THEN 'LOCAL_TEMPORARY'
+	// 			ELSE table_type
+	// 		END AS TABLE_TYPE
+	// 	FROM information_schema.tables
+	// 	WHERE table_schema = 'mydb'
+	// 		AND table_name = 'mytable'
+	// 	HAVING table_type IN ('TABLE', 'VIEW')
+	// 	ORDER BY table_type, table_schema, table_name`,
+	// 	[]sql.Row{{"mydb", "mytable", "TABLE"}},
+	// },
+	// {
+	// 	`SELECT REGEXP_MATCHES("bopbeepbop", "bop")`,
+	// 	[]sql.Row{{[]interface{}{"bop", "bop"}}},
+	// },
+	// {
+	// 	`SELECT EXPLODE(REGEXP_MATCHES("bopbeepbop", "bop"))`,
+	// 	[]sql.Row{{"bop"}, {"bop"}},
+	// },
+	// {
+	// 	`SELECT EXPLODE(REGEXP_MATCHES("helloworld", "bop"))`,
+	// 	nil,
+	// },
+	// {
+	// 	`SELECT EXPLODE(REGEXP_MATCHES("", ""))`,
+	// 	[]sql.Row{{""}},
+	// },
+	// {
+	// 	`SELECT REGEXP_MATCHES(NULL, "")`,
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	`SELECT REGEXP_MATCHES("", NULL)`,
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	`SELECT REGEXP_MATCHES("", "", NULL)`,
+	// 	[]sql.Row{{nil}},
+	// },
+	// {
+	// 	"SELECT * FROM newlinetable WHERE s LIKE '%text%'",
+	// 	[]sql.Row{
+	// 		{int64(1), "\nthere is some text IN here"},
+	// 		{int64(2), "there is some\ntext IN here"},
+	// 		{int64(3), "there is some text\nin here"},
+	// 		{int64(4), "there is some text IN here\n"},
+	// 		{int64(5), "there is some text IN here"},
+	// 	},
+	// },
+	// {
+	// 	`SELECT i FROM mytable WHERE i = (SELECT 1)`,
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	`SELECT i FROM mytable WHERE i IN (SELECT i FROM mytable)`,
+	// 	[]sql.Row{
+	// 		{int64(1)},
+	// 		{int64(2)},
+	// 		{int64(3)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT i FROM mytable WHERE i NOT IN (SELECT i FROM mytable ORDER BY i ASC LIMIT 2)`,
+	// 	[]sql.Row{
+	// 		{int64(3)},
+	// 	},
+	// },
+	// {
+	// 	`SELECT (SELECT i FROM mytable ORDER BY i ASC LIMIT 1) AS x`,
+	// 	[]sql.Row{{int64(1)}},
+	// },
+	// {
+	// 	`SELECT DISTINCT n FROM bigtable ORDER BY t`,
+	// 	[]sql.Row{
+	// 		{int64(1)},
+	// 		{int64(9)},
+	// 		{int64(7)},
+	// 		{int64(3)},
+	// 		{int64(2)},
+	// 		{int64(8)},
+	// 		{int64(6)},
+	// 		{int64(5)},
+	// 		{int64(4)},
+	// 	},
+	// },
+	// {
+	// 	"SELECT pk,pk1,pk2 FROM one_pk, two_pk ORDER BY 1,2,3",
+	// 	[]sql.Row{
+	// 		{0, 0, 0},
+	// 		{0, 0, 1},
+	// 		{0, 1, 0},
+	// 		{0, 1, 1},
+	// 		{1, 0, 0},
+	// 		{1, 0, 1},
+	// 		{1, 1, 0},
+	// 		{1, 1, 1},
+	// 		{2, 0, 0},
+	// 		{2, 0, 1},
+	// 		{2, 1, 0},
+	// 		{2, 1, 1},
+	// 		{3, 0, 0},
+	// 		{3, 0, 1},
+	// 		{3, 1, 0},
+	// 		{3, 1, 1},
+	// 	},
+	// },
+	// {
+	// 	"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 AND pk2=1 ORDER BY 1,2",
+	// 	[]sql.Row{
+	// 		{0, 30},
+	// 		{10, 30},
+	// 		{20, 30},
+	// 		{30, 30},
+	// 	},
+	// },
+	// {
+	// 	"SELECT t1.c1,t2.c2 FROM one_pk t1, two_pk t2 WHERE pk1=1 OR pk2=1 ORDER BY 1,2",
+	// 	[]sql.Row{
+	// 		{0, 10},
+	// 		{0, 20},
+	// 		{0, 30},
+	// 		{10, 10},
+	// 		{10, 20},
+	// 		{10, 30},
+	// 		{20, 10},
+	// 		{20, 20},
+	// 		{20, 30},
+	// 		{30, 10},
+	// 		{30, 20},
+	// 		{30, 30},
+	// 	},
+	// },
+	// {
+	// 	"SELECT pk,pk2 FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2",
+	// 	[]sql.Row{
+	// 		{1, 1},
+	// 		{1, 1},
+	// 	},
+	// },
+	// {
+	// 	"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE pk=0 AND pk1=0 OR pk2=1 ORDER BY 1,2,3",
+	// 	[]sql.Row{
+	// 		{0, 0, 0},
+	// 		{0, 0, 1},
+	// 		{0, 1, 1},
+	// 		{1, 0, 1},
+	// 		{1, 1, 1},
+	// 		{2, 0, 1},
+	// 		{2, 1, 1},
+	// 		{3, 0, 1},
+	// 		{3, 1, 1},
+	// 	},
+	// },
+	// {
+	// 	"SELECT pk,pk1,pk2 FROM one_pk,two_pk WHERE one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
+	// 	[]sql.Row{
+	// 		{0, 0, 0},
+	// 		{1, 0, 1},
+	// 		{2, 1, 0},
+	// 		{3, 1, 1},
+	// 	},
+	// },
+	// {
+	// 	"SELECT one_pk.c5,pk1,pk2 FROM one_pk,two_pk WHERE pk=pk1 ORDER BY 1,2,3",
+	// 	[]sql.Row{
+	// 		{0, 0, 0},
+	// 		{0, 0, 1},
+	// 		{10, 1, 0},
+	// 		{10, 1, 1},
+	// 	},
+	// },
+	// {
+	// 	"SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
+	// 	[]sql.Row{
+	// 		{1, 0, 1},
+	// 	},
+	// },
+	// {
+	// 	"SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk on pk=pk1 ORDER BY 1,2,3",
+	// 	[]sql.Row{
+	// 		{0, 0, 0},
+	// 		{0, 0, 1},
+	// 		{1, 1, 0},
+	// 		{1, 1, 1},
+	// 		{2, nil, nil},
+	// 		{3, nil, nil},
+	// 	},
+	// },
 	{
 		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i ORDER BY 1",
 		[]sql.Row{

--- a/engine_test.go
+++ b/engine_test.go
@@ -345,7 +345,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2",
+		"SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 order by i",
 		[]sql.Row{
 			{int64(1), int64(1), "third"},
 			{int64(2), int64(2), "second"},
@@ -382,7 +382,7 @@ var queries = []queryTest{
 	},
 	{
 		"SELECT s FROM mytable INNER JOIN othertable " +
-				"ON substring(s2, 1, 2) != '' AND i = i2",
+				"ON substring(s2, 1, 2) != '' AND i = i2 order by 1",
 		[]sql.Row{
 			{"first row"},
 			{"second row"},

--- a/engine_test.go
+++ b/engine_test.go
@@ -1580,6 +1580,25 @@ var queries = []queryTest{
 		},
 	},
 	{
+		"SELECT pk,i,f FROM one_pk LEFT JOIN niltable on pk=i ORDER BY 1",
+		[]sql.Row{
+			{0, nil, nil},
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+			{3, nil, nil},
+		},
+	},
+	{
+		"SELECT pk,i,f FROM one_pk RIGHT JOIN niltable on pk=i ORDER BY 2,3",
+		[]sql.Row{
+			{nil, nil, nil},
+			{nil, nil, float64(3.0)},
+			{1, int64(1), float64(1.0)},
+			{2, int64(2), float64(2.0)},
+			{nil, int64(4), nil},
+		},
+	},
+	{
 		"SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk on one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0, 0, 0},

--- a/memory/mergeable_index.go
+++ b/memory/mergeable_index.go
@@ -126,8 +126,7 @@ func (i *MergeableIndexLookup) IsMergeable(lookup sql.IndexLookup) bool {
 func (i *MergeableIndexLookup) Values(p sql.Partition) (sql.IndexValueIter, error) {
 	var exprs []sql.Expression
 	for exprI, expr := range i.Index.ColumnExpressions() {
-		lit, typ := getType(i.Key[exprI])
-		exprs = append(exprs, expression.NewEquals(expr, expression.NewLiteral(lit, typ)))
+		exprs = append(exprs, expression.NewEquals(expr, expression.NewLiteral(i.Key[exprI], expr.Type())))
 	}
 
 	return &indexValIter{

--- a/memory/unmergeable_index.go
+++ b/memory/unmergeable_index.go
@@ -139,8 +139,7 @@ func (u *indexValIter) Close() error {
 func (u *UnmergeableIndexLookup) Values(p sql.Partition) (sql.IndexValueIter, error) {
 	var exprs []sql.Expression
 	for exprI, expr := range u.idx.Exprs {
-		lit, typ := getType(u.key[exprI])
-		exprs = append(exprs, expression.NewEquals(expr, expression.NewLiteral(lit, typ)))
+		exprs = append(exprs, expression.NewEquals(expr, expression.NewLiteral(u.key[exprI], expr.Type())))
 	}
 
 	return &indexValIter{

--- a/sql/analyzer/assign_indexes.go
+++ b/sql/analyzer/assign_indexes.go
@@ -552,9 +552,6 @@ func indexesIntersection(
 	a *Analyzer,
 	left, right map[string]*indexLookup,
 ) map[string]*indexLookup {
-	if left == nil {
-		return right
-	}
 
 	var result = make(map[string]*indexLookup)
 

--- a/sql/analyzer/assign_indexes.go
+++ b/sql/analyzer/assign_indexes.go
@@ -332,23 +332,27 @@ func findTables(e sql.Expression) []string {
 	return names
 }
 
+func unifyExpression(aliases map[string]sql.Expression, e sql.Expression) sql.Expression {
+	uex := e
+	name := e.String()
+	if n, ok := e.(sql.Nameable); ok {
+		name = n.Name()
+	}
+
+	if aliases != nil && len(aliases) > 0 {
+		if alias, ok := aliases[name]; ok {
+			uex = alias
+		}
+	}
+
+	return uex
+}
+
 func unifyExpressions(aliases map[string]sql.Expression, expr ...sql.Expression) []sql.Expression {
 	expressions := make([]sql.Expression, len(expr))
 
 	for i, e := range expr {
-		uex := e
-		name := e.String()
-		if n, ok := e.(sql.Nameable); ok {
-			name = n.Name()
-		}
-
-		if aliases != nil && len(aliases) > 0 {
-			if alias, ok := aliases[name]; ok {
-				uex = alias
-			}
-		}
-
-		expressions[i] = uex
+		expressions[i] = unifyExpression(aliases, e)
 	}
 
 	return expressions

--- a/sql/analyzer/assign_indexes_test.go
+++ b/sql/analyzer/assign_indexes_test.go
@@ -44,7 +44,7 @@ func TestNegateIndex(t *testing.T) {
 		),
 	)
 
-	result, err := assignIndexes(a, node)
+	result, err := assignIndexes(sql.NewEmptyContext(), a, node)
 	require.NoError(err)
 
 	lookupIdxs, ok := result["t1"]
@@ -129,7 +129,7 @@ func TestAssignIndexes(t *testing.T) {
 		),
 	)
 
-	result, err := assignIndexes(a, node)
+	result, err := assignIndexes(sql.NewEmptyContext(), a, node)
 	require.NoError(err)
 
 	lookupIdxs, ok := result["t1"]

--- a/sql/analyzer/assign_indexes_test.go
+++ b/sql/analyzer/assign_indexes_test.go
@@ -163,7 +163,7 @@ func TestAssignIndexes(t *testing.T) {
 		),
 	)
 
-	result, err = assignIndexes(a, node)
+	result, err = assignIndexes(sql.NewEmptyContext(), a, node)
 	require.NoError(err)
 
 	_, ok = result["t1"]
@@ -180,7 +180,7 @@ func TestAssignIndexes(t *testing.T) {
 		),
 	)
 
-	result, err = assignIndexes(a, node)
+	result, err = assignIndexes(sql.NewEmptyContext(), a, node)
 	require.NoError(err)
 
 	_, ok = result["t1"]

--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -18,13 +18,13 @@ func (f filters) merge(f2 filters) {
 func exprToTableFilters(expr sql.Expression) filters {
 	filtersByTable := make(filters)
 	for _, expr := range splitExpression(expr) {
-		var seenTables = make(map[string]struct{})
+		var seenTables = make(map[string]bool)
 		var lastTable string
 		sql.Inspect(expr, func(e sql.Expression) bool {
 			f, ok := e.(*expression.GetField)
 			if ok {
-				if _, ok := seenTables[f.Table()]; !ok {
-					seenTables[f.Table()] = struct{}{}
+				if !seenTables[f.Table()] {
+					seenTables[f.Table()] = true
 					lastTable = f.Table()
 				}
 			}

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -26,6 +26,20 @@ func optimizePrimaryKeyJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Nod
 		return n, nil
 	}
 
+	numTables := 0
+	plan.Inspect(n, func(node sql.Node) bool {
+		switch node.(type) {
+		case *plan.ResolvedTable:
+			numTables++
+		}
+		return true
+	})
+
+	if numTables > 2 {
+		a.Log("Skipping join optimization, more than 2 tables")
+		return n, nil
+	}
+
 	a.Log("finding indexes for joins")
 	indexes, aliases, err := findJoinIndexes(ctx, a, n)
 	if err != nil {

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -136,6 +136,7 @@ func findTableName(node sql.Node) string {
 	plan.Inspect(node, func(node sql.Node) bool {
 		switch node := node.(type) {
 		case *plan.ResolvedTable:
+			// TODO: this is over specific, we only need one side of the join to be indexable
 			if it, ok := node.Table.(sql.IndexableTable); ok {
 				tableName = it.Name()
 				return false

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -1,0 +1,402 @@
+package analyzer
+
+import (
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/src-d/go-mysql-server/sql/plan"
+)
+
+// optimizePrimaryKeyJoins takes InnerJoins where the join condition is the primary keys of two tables and replaces them with an
+// IndexedJoin on the same two tables. Only works for equality expressions.
+func optimizePrimaryKeyJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	span, ctx := ctx.Span("optimizePrimaryKeyJoins")
+	defer span.Finish()
+
+	a.Log("optimizePrimaryKeyJoins, node of type: %T", n)
+	if !n.Resolved() {
+		return n, nil
+	}
+
+	// skip certain queries (list is probably incomplete)
+	switch n.(type) {
+	case *plan.InsertInto, *plan.CreateIndex:
+		return n, nil
+	}
+
+	a.Log("finding fields used by tables")
+	fieldsByTable := findFieldsByTable(ctx, n)
+
+	a.Log("finding InnerJoin conditions")
+	innerJoinConds := findInnerJoinConds(ctx, n)
+
+	a.Log("finding indexes for joins")
+	indexes, err := assignJoinIndexes(ctx, a, n)
+	if err != nil {
+		return nil, err
+	}
+
+	a.Log("replacing InnerJoins with IndexJoins")
+
+	return transformInnerJoins(a, n, innerJoinConds, indexes, fieldsByTable)
+}
+
+func transformInnerJoins(
+	a *Analyzer,
+	n sql.Node,
+	joinConds []sql.Expression,
+	indexes []sql.Index,
+	fieldsByTable map[string][]string,
+) (sql.Node, error) {
+	return nil, nil
+}
+
+func findInnerJoinConds(ctx *sql.Context, n sql.Node) []sql.Expression {
+	span, _ := ctx.Span("find_InnerJoins")
+	defer span.Finish()
+
+	// Find all inner joins by table
+	joinConds := make([]sql.Expression, 0)
+	plan.Inspect(n, func(node sql.Node) bool {
+		switch node := node.(type) {
+		case *plan.InnerJoin:
+			joinConds = append(joinConds, node.Cond)
+		}
+		return true
+	})
+
+	return joinConds
+}
+
+// index munging
+
+// Assign indexes to the join conditions and returns the sql.Indexes assigned
+func assignJoinIndexes(ctx *sql.Context, a *Analyzer, node sql.Node) ([]sql.Index, error) {
+	a.Log("assigning indexes, node of type: %T", node)
+
+	indexSpan, _ := ctx.Span("assign_join_indexes")
+	defer indexSpan.Finish()
+
+	var indexes []sql.Index
+	// release all unused indexes
+	defer func() {
+		if indexes == nil {
+			return
+		}
+
+		for _, index := range indexes {
+			a.Catalog.ReleaseIndex(index)
+		}
+	}()
+
+	aliases := make(map[string]sql.Expression)
+	var err error
+
+	fn := func(ex sql.Expression) bool {
+		if alias, ok := ex.(*expression.Alias); ok {
+			if _, ok := aliases[alias.Name()]; !ok {
+				aliases[alias.Name()] = alias.Child
+			}
+		}
+		return true
+	}
+
+	plan.Inspect(node, func(node sql.Node) bool {
+		innerJoin, ok := node.(*plan.InnerJoin)
+		if !ok {
+			return true
+		}
+
+		fn(innerJoin.Cond)
+
+		var idxes []sql.Index
+		idxes, err = getJoinIndexes(innerJoin.Cond, aliases, a)
+		if err != nil {
+			return false
+		}
+
+		indexes = addManyToSet(indexes, idxes)
+
+		return true
+	})
+
+	return indexes, err
+}
+
+
+func addManyToSet(indexes []sql.Index, toAdd []sql.Index) []sql.Index {
+	for _, i := range toAdd {
+		indexes = addToSet(indexes, i)
+	}
+	return indexes
+}
+
+func addToSet(indexes []sql.Index, index sql.Index) []sql.Index {
+	for _, idx := range indexes {
+		if idx == index {
+			return indexes
+		}
+	}
+
+	return append(indexes, index)
+}
+
+// Returns the left and right indexes for the two sides of the equality expression given. If either one is nil, nil is
+// returned for both results.
+func getJoinEqualityIndex(
+		a *Analyzer,
+		e *expression.Equals,
+		aliases map[string]sql.Expression,
+) (leftIdx sql.Index, rightIdx sql.Index) {
+
+	// Only handle column expressions -- evaluable expressions will have already gotten pushed down
+	// to their origin tables
+	if isEvaluable(e.Left()) || isEvaluable(e.Right()) {
+		return nil, nil
+	}
+
+	leftIdx, rightIdx =
+		a.Catalog.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Left())...),
+		a.Catalog.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Right())...)
+
+	if leftIdx == nil || rightIdx == nil {
+		return nil, nil
+	}
+
+	return leftIdx, rightIdx
+}
+
+func getJoinIndexes(e sql.Expression, aliases map[string]sql.Expression, a *Analyzer) ([]sql.Index, error) {
+	var result []sql.Index
+
+	switch e := e.(type) {
+	case *expression.Equals:
+		leftIdx, rightIdx := getJoinEqualityIndex(a, e, aliases)
+		if leftIdx != nil && rightIdx != nil {
+			result = append(result, leftIdx, rightIdx)
+		}
+
+		// TODO: fill in with multi-column indexes
+	// case *expression.And:
+	// 	exprs := splitExpression(e)
+	// 	used := make(map[sql.Expression]struct{})
+	//
+	// 	result, err := getMultiColumnIndexes(exprs, a, used, aliases)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	//
+	// 	for _, e := range exprs {
+	// 		if _, ok := used[e]; ok {
+	// 			continue
+	// 		}
+	//
+	// 		indexes, err := getIndexes(e, aliases, a)
+	// 		if err != nil {
+	// 			return nil, err
+	// 		}
+	//
+	// 		result = indexesIntersection(a, result, indexes)
+	// 	}
+	//
+	// 	return result, nil
+	}
+
+	return result, nil
+}
+
+// getComparisonIndex returns the index and index lookup for the given
+// comparison if any index can be found.
+// It works for the following comparisons: eq, lt, gt, gte and lte.
+// TODO(erizocosmico): add support for BETWEEN once the appropiate interfaces
+// can handle inclusiveness on both sides.
+func getComparisonJoinIndex(
+		a *Analyzer,
+		e expression.Comparer,
+		aliases map[string]sql.Expression,
+) (sql.Index, sql.IndexLookup, error) {
+	left, right := e.Left(), e.Right()
+	// if the form is SOMETHING OP {INDEXABLE EXPR}, swap it, so it's {INDEXABLE EXPR} OP SOMETHING
+	if !isEvaluable(right) {
+		left, right = right, left
+	}
+
+	if !isEvaluable(left) && isEvaluable(right) {
+		idx := a.Catalog.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, left)...)
+		if idx != nil {
+			value, err := right.Eval(sql.NewEmptyContext(), nil)
+			if err != nil {
+				a.Catalog.ReleaseIndex(idx)
+				return nil, nil, err
+			}
+
+			lookup, err := comparisonIndexLookup(e, idx, value)
+			if err != nil || lookup == nil {
+				a.Catalog.ReleaseIndex(idx)
+				return nil, nil, err
+			}
+
+			return idx, lookup, nil
+		}
+	}
+
+	return nil, nil, nil
+}
+
+func comparisonJoinIndexLookup(
+		c expression.Comparer,
+		idx sql.Index,
+		values ...interface{},
+) (sql.IndexLookup, error) {
+	switch c.(type) {
+	case *expression.Equals:
+		return idx.Get(values...)
+	case *expression.GreaterThan:
+		index, ok := idx.(sql.DescendIndex)
+		if !ok {
+			return nil, nil
+		}
+
+		return index.DescendGreater(values...)
+	case *expression.GreaterThanOrEqual:
+		index, ok := idx.(sql.AscendIndex)
+		if !ok {
+			return nil, nil
+		}
+
+		return index.AscendGreaterOrEqual(values...)
+	case *expression.LessThan:
+		index, ok := idx.(sql.AscendIndex)
+		if !ok {
+			return nil, nil
+		}
+
+		return index.AscendLessThan(values...)
+	case *expression.LessThanOrEqual:
+		index, ok := idx.(sql.DescendIndex)
+		if !ok {
+			return nil, nil
+		}
+
+		return index.DescendLessOrEqual(values...)
+	}
+
+	return nil, nil
+}
+
+func getMultiColumnJoinIndexes(
+		exprs []sql.Expression,
+		a *Analyzer,
+		used map[sql.Expression]struct{},
+		aliases map[string]sql.Expression,
+) (map[string]*indexLookup, error) {
+	result := make(map[string]*indexLookup)
+	columnExprs := columnExprsByTable(exprs)
+	for table, exps := range columnExprs {
+		exprsByOp := groupExpressionsByOperator(exps)
+		for _, exps := range exprsByOp {
+			cols := make([]sql.Expression, len(exps))
+			for i, e := range exps {
+				cols[i] = e.col
+			}
+
+			exprList := a.Catalog.ExpressionsWithIndexes(a.Catalog.CurrentDatabase(), cols...)
+
+			var selected []sql.Expression
+			for _, l := range exprList {
+				if len(l) > len(selected) {
+					selected = l
+				}
+			}
+
+			if len(selected) > 0 {
+				index, lookup, err := getMultiColumnIndexForExpressions(a, selected, exps, used, aliases)
+				if err != nil || lookup == nil {
+					if index != nil {
+						a.Catalog.ReleaseIndex(index)
+					}
+
+					if err != nil {
+						return nil, err
+					}
+				}
+
+				if lookup != nil {
+					if _, ok := result[table]; ok {
+						result = indexesIntersection(a, result, map[string]*indexLookup{
+							table: &indexLookup{lookup, []sql.Index{index}},
+						})
+					} else {
+						result[table] = &indexLookup{lookup, []sql.Index{index}}
+					}
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func getMultiColumnJoinIndexForExpressions(
+		a *Analyzer,
+		selected []sql.Expression,
+		exprs []columnExpr,
+		used map[sql.Expression]struct{},
+		aliases map[string]sql.Expression,
+) (index sql.Index, lookup sql.IndexLookup, err error) {
+	index = a.Catalog.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, selected...)...)
+	if index != nil {
+		var first sql.Expression
+		for _, e := range exprs {
+			if e.col == selected[0] {
+				first = e.expr
+				break
+			}
+		}
+
+		if first == nil {
+			return
+		}
+
+		switch e := first.(type) {
+		case *expression.Equals,
+			*expression.LessThan,
+			*expression.GreaterThan,
+			*expression.LessThanOrEqual,
+			*expression.GreaterThanOrEqual:
+			var values = make([]interface{}, len(index.Expressions()))
+			for i, e := range index.Expressions() {
+				col := findColumn(exprs, e)
+				used[col.expr] = struct{}{}
+				var val interface{}
+				val, err = col.val.Eval(sql.NewEmptyContext(), nil)
+				if err != nil {
+					return
+				}
+				values[i] = val
+			}
+
+			lookup, err = comparisonIndexLookup(e.(expression.Comparer), index, values...)
+		case *expression.Between:
+			var lowers = make([]interface{}, len(index.Expressions()))
+			var uppers = make([]interface{}, len(index.Expressions()))
+			for i, e := range index.Expressions() {
+				col := findColumn(exprs, e)
+				used[col.expr] = struct{}{}
+				between := col.expr.(*expression.Between)
+				lowers[i], err = between.Lower.Eval(sql.NewEmptyContext(), nil)
+				if err != nil {
+					return
+				}
+
+				uppers[i], err = between.Upper.Eval(sql.NewEmptyContext(), nil)
+				if err != nil {
+					return
+				}
+			}
+
+			lookup, err = betweenIndexLookup(index, uppers, lowers)
+		}
+	}
+
+	return
+}

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -12,10 +12,10 @@ type Aliases map[string]sql.Expression
 // optimizeJoins takes two-table InnerJoins where the join condition is an equality on an index of one of the tables,
 // and replaces it with an equivalent IndexedJoin of the same two tables.
 func optimizeJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
-	span, ctx := ctx.Span("optimizePrimaryKeyJoins")
+	span, ctx := ctx.Span("optimize_joins")
 	defer span.Finish()
 
-	a.Log("optimizePrimaryKeyJoins, node of type: %T", n)
+	a.Log("optimize_joins, node of type: %T", n)
 	if !n.Resolved() {
 		return n, nil
 	}
@@ -308,8 +308,8 @@ func getJoinEqualityIndex(
 		aliases map[string]sql.Expression,
 ) (leftIdx sql.Index, rightIdx sql.Index) {
 
-	// Only handle column expressions -- evaluable expressions will have already gotten pushed down
-	// to their origin tables
+	// Only handle column expressions for these join indexes. Evaluable expression like `col=literal` will get pushed
+	// down where possible.
 	if isEvaluable(e.Left()) || isEvaluable(e.Right()) {
 		return nil, nil
 	}

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -9,9 +9,9 @@ import (
 
 type Aliases map[string]sql.Expression
 
-// optimizePrimaryKeyJoins takes InnerJoins where the join condition is the primary keys of two tables and replaces them with an
-// IndexedJoin on the same two tables. Only works for equality expressions.
-func optimizePrimaryKeyJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+// optimizeJoins takes two-table InnerJoins where the join condition is an equality on an index of one of the tables,
+// and replaces it with an equivalent IndexedJoin of the same two tables.
+func optimizeJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	span, ctx := ctx.Span("optimizePrimaryKeyJoins")
 	defer span.Finish()
 

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -111,7 +111,7 @@ func transformInnerJoins(
 				return nil, err
 			}
 
-			return plan.NewIndexedJoin(leftNode, rightNode, joinCond, leftTableExpr, rightTableIndex), nil
+			return plan.NewIndexedJoin(leftNode, rightNode, joinType, joinCond, leftTableExpr, rightTableIndex), nil
 		default:
 			return node, nil
 		}

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -39,6 +39,7 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 		return true
 	})
 	if incompatibleJoin {
+		a.Log("skipping pushdown for incompatible join")
 		return n, nil
 	}
 

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -151,7 +151,7 @@ func transformPushdown(
 				return nil, err
 			}
 			// After pushing down the filter, we need to fix field indexes as well
-			return transformExpressioners(n)
+			return fixFieldIndexesForExpressions(n)
 		case *plan.ResolvedTable:
 			table, err := pushdownTable(
 				a,
@@ -165,9 +165,9 @@ func transformPushdown(
 			if err != nil {
 				return nil, err
 			}
-			return transformExpressioners(table)
+			return fixFieldIndexesForExpressions(table)
 		default:
-			return transformExpressioners(node)
+			return fixFieldIndexesForExpressions(node)
 		}
 	})
 
@@ -189,7 +189,8 @@ func transformPushdown(
 	return node, nil
 }
 
-func transformExpressioners(node sql.Node) (sql.Node, error) {
+// Transforms the expressions in the Node given, fixing the field indexes.
+func fixFieldIndexesForExpressions(node sql.Node) (sql.Node, error) {
 	if _, ok := node.(sql.Expressioner); !ok {
 		return node, nil
 	}

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -45,7 +45,9 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	// First step is to find all col exprs and group them by the table they mention.
 	// Even if they appear multiple times, only the first one will be used.
 	a.Log("finding used columns in node")
+	colSpan, _ := ctx.Span("find_pushdown_columns")
 	fieldsByTable := findFieldsByTable(ctx, n)
+	colSpan.Finish()
 
 	a.Log("finding filters in node")
 	filters := findFilters(ctx, n)

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -41,7 +41,7 @@ var OnceAfterDefault = []Rule{
 	{"prune_columns", pruneColumns},
 	{"convert_dates", convertDates},
 	{"pushdown", pushdown},
-	{"optimizeJoins", optimizePrimaryKeyJoins},
+	{"optimizeJoins", optimizeJoins},
 	{"erase_projection", eraseProjection},
 }
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -41,7 +41,7 @@ var OnceAfterDefault = []Rule{
 	{"prune_columns", pruneColumns},
 	{"convert_dates", convertDates},
 	{"pushdown", pushdown},
-	{"optimizeJoins", optimizeJoins},
+	{"optimize_joins", optimizeJoins},
 	{"erase_projection", eraseProjection},
 }
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -40,8 +40,8 @@ var OnceAfterDefault = []Rule{
 	{"assign_catalog", assignCatalog},
 	{"prune_columns", pruneColumns},
 	{"convert_dates", convertDates},
-	{"optimizeJoins", optimizePrimaryKeyJoins},
 	{"pushdown", pushdown},
+	{"optimizeJoins", optimizePrimaryKeyJoins},
 	{"erase_projection", eraseProjection},
 }
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -41,6 +41,7 @@ var OnceAfterDefault = []Rule{
 	{"prune_columns", pruneColumns},
 	{"convert_dates", convertDates},
 	{"pushdown", pushdown},
+	{"optimizeJoins", optimizePrimaryKeyJoins},
 	{"erase_projection", eraseProjection},
 }
 

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -40,8 +40,8 @@ var OnceAfterDefault = []Rule{
 	{"assign_catalog", assignCatalog},
 	{"prune_columns", pruneColumns},
 	{"convert_dates", convertDates},
-	{"pushdown", pushdown},
 	{"optimizeJoins", optimizePrimaryKeyJoins},
+	{"pushdown", pushdown},
 	{"erase_projection", eraseProjection},
 }
 

--- a/sql/core.go
+++ b/sql/core.go
@@ -31,6 +31,10 @@ var (
 	// node or expression is called with an invalid number of arguments.
 	ErrInvalidChildrenNumber = errors.NewKind("%T: invalid children number, got %d, expected %d")
 
+	// ErrInvalidChildType is returned when the WithChildren method of a
+	// node or expression is called with an invalid child type. This error is indicative of a bug.
+	ErrInvalidChildType = errors.NewKind("%T: invalid child type, got %T, expected %T")
+
 	// ErrDeleteRowNotFound
 	ErrDeleteRowNotFound = errors.NewKind("row was not found when attempting to delete").New()
 )

--- a/sql/plan/indexed_join.go
+++ b/sql/plan/indexed_join.go
@@ -120,8 +120,14 @@ func (i *indexedJoinIter) loadPrimary() error {
 
 func (i *indexedJoinIter) loadSecondary() (sql.Row, error) {
 	if i.secondary == nil {
-		// TODO: get real value
-		lookup, err := i.index.Get(i.primaryRow[0])
+		// TODO: better checking, this only works for certain phrasings
+		c := i.cond.Children()[1]
+		key, err := c.Eval(sql.NewEmptyContext(), i.primaryRow)
+		if err != nil {
+			return nil, err
+		}
+
+		lookup, err := i.index.Get(key)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/plan/indexed_join.go
+++ b/sql/plan/indexed_join.go
@@ -1,0 +1,177 @@
+package plan
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/src-d/go-mysql-server/sql"
+	"io"
+	"reflect"
+)
+
+func indexedJoinRowIter(
+		ctx *sql.Context,
+		typ joinType,
+		left sql.Node,
+		right sql.IndexableTable,
+		cond sql.Expression,
+) (sql.RowIter, error) {
+	var leftName, rightName string
+	if leftTable, ok := left.(sql.Nameable); ok {
+		leftName = leftTable.Name()
+	} else {
+		leftName = reflect.TypeOf(left).String()
+	}
+
+	if rightTable, ok := right.(sql.Nameable); ok {
+		rightName = rightTable.Name()
+	} else {
+		rightName = reflect.TypeOf(right).String()
+	}
+
+	span, ctx := ctx.Span("plan."+typ.String(), opentracing.Tags{
+		"left":  leftName,
+		"right": rightName,
+	})
+
+	l, err := left.RowIter(ctx)
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+	return sql.NewSpanIter(span, &indexedJoinIter{
+		typ:               typ,
+		primary:           l,
+		secondaryTbl:      right,
+		secondaryProvider: makeIndexProvider(right),
+		ctx:               ctx,
+		cond:              cond,
+	}), nil
+}
+
+func makeIndexProvider(tbl sql.IndexableTable) sql.IndexRowIterProvider {
+	return nil
+}
+
+// joinIter is a generic iterator for all join types.
+type indexedJoinIter struct {
+	typ               joinType
+	primary           sql.RowIter
+	secondaryTbl      sql.IndexableTable
+	secondaryProvider sql.IndexRowIterProvider
+	secondary         sql.RowIter
+	ctx               *sql.Context
+	cond              sql.Expression
+
+	primaryRow sql.Row
+	foundMatch bool
+	rowSize    int
+}
+
+func (i *indexedJoinIter) loadPrimary() error {
+	if i.primaryRow == nil {
+		r, err := i.primary.Next()
+		if err != nil {
+			return err
+		}
+
+		i.primaryRow = r
+		i.foundMatch = false
+	}
+
+	return nil
+}
+
+func (i *indexedJoinIter) loadSecondary() (row sql.Row, err error) {
+	if i.secondary == nil {
+		var iter sql.RowIter
+		iter, err = i.secondaryProvider.RowIter(i.ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		i.secondary = iter
+	}
+
+	rightRow, err := i.secondary.Next()
+	if err != nil {
+		if err == io.EOF {
+			i.secondary = nil
+			i.primaryRow = nil
+			return nil, io.EOF
+		}
+		return nil, err
+	}
+
+	return rightRow, nil
+}
+
+
+func (i *indexedJoinIter) Next() (sql.Row, error) {
+	for {
+		if err := i.loadPrimary(); err != nil {
+			return nil, err
+		}
+
+		primary := i.primaryRow
+		secondary, err := i.loadSecondary()
+		if err != nil {
+			if err == io.EOF {
+				if !i.foundMatch && (i.typ == leftJoin || i.typ == rightJoin) {
+					return i.buildRow(primary, nil), nil
+				}
+				continue
+			}
+			return nil, err
+		}
+
+		row := i.buildRow(primary, secondary)
+		v, err := i.cond.Eval(i.ctx, row)
+		if err != nil {
+			return nil, err
+		}
+
+		if v == false {
+			continue
+		}
+
+		i.foundMatch = true
+		return row, nil
+	}
+}
+
+// buildRow builds the resulting row using the rows from the primary and
+// secondary branches depending on the join type.
+func (i *indexedJoinIter) buildRow(primary, secondary sql.Row) sql.Row {
+	var row sql.Row
+	if i.rowSize > 0 {
+		row = make(sql.Row, i.rowSize)
+	} else {
+		row = make(sql.Row, len(primary)+len(secondary))
+		i.rowSize = len(row)
+	}
+
+	copy(row, primary)
+	copy(row[len(primary):], secondary)
+
+	return row
+}
+
+func (i *indexedJoinIter) Close() (err error) {
+	i.secondary = nil
+
+	if i.primary != nil {
+		if err = i.primary.Close(); err != nil {
+			if i.secondary != nil {
+				_ = i.secondary.Close()
+			}
+			return err
+		}
+
+	}
+
+	if i.secondary != nil {
+		err = i.secondary.Close()
+	}
+
+	return err
+}
+

--- a/sql/plan/indexed_join.go
+++ b/sql/plan/indexed_join.go
@@ -17,7 +17,7 @@ type IndexedJoin struct {
 
 func (ij *IndexedJoin) String() string {
 	pr := sql.NewTreePrinter()
-	_ = pr.WriteNode("InnerJoin(%s)", ij.Cond)
+	_ = pr.WriteNode("IndexedJoin(%s)", ij.Cond)
 	_ = pr.WriteChildren(ij.Left.String(), ij.Right.String())
 	return pr.String()
 }

--- a/sql/plan/indexed_join.go
+++ b/sql/plan/indexed_join.go
@@ -159,6 +159,7 @@ func (i *indexedJoinIter) loadSecondary() (sql.Row, error) {
 		span, ctx := i.ctx.Span("plan.IndexedJoin indexed lookup")
 		rowIter, err := i.secondaryProvider.RowIter(ctx)
 		if err != nil {
+			span.Finish()
 			return nil, err
 		}
 
@@ -232,8 +233,6 @@ func (i *indexedJoinIter) buildRow(primary, secondary sql.Row) sql.Row {
 }
 
 func (i *indexedJoinIter) Close() (err error) {
-	i.secondary = nil
-
 	if i.primary != nil {
 		if err = i.primary.Close(); err != nil {
 			if i.secondary != nil {
@@ -241,10 +240,10 @@ func (i *indexedJoinIter) Close() (err error) {
 			}
 			return err
 		}
-
 	}
 
 	if i.secondary != nil {
+		i.secondary = nil
 		err = i.secondary.Close()
 	}
 

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -38,7 +38,7 @@ func (i *IndexedTableAccess) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		return nil, err
 	}
 
-	return sql.NewTableIter(ctx, i.indexedTable, partIter), nil
+	return sql.NewTableRowIter(ctx, i.indexedTable, partIter), nil
 }
 
 func (i *IndexedTableAccess) WithChildren(children ...sql.Node) (sql.Node, error) {

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -1,0 +1,63 @@
+package plan
+
+import (
+	"github.com/src-d/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
+)
+
+var ErrNoIndexableTable = errors.NewKind("expected an IndexableTable, couldn't find one in %v")
+var ErrNoIndexedTableAccess = errors.NewKind("expected an IndexedTableAccess, couldn't find one in %v")
+var ErrIndexedTableAccessNotInitialized = errors.NewKind("IndexedTableAccess must be initialized before RowIter is called")
+
+// IndexedTableAccess represents an indexed lookup of a particular ResolvedTable. Unlike other kinds of UnaryNodes,
+// this node supports being repeatedly initialized and being iterated over multiple times, potentially with different
+// values returned every iteration. Used during analysis as part of the process of optimizing joins, replacing
+// (wrapping) a ResolvedTable.
+type IndexedTableAccess struct {
+	*ResolvedTable
+	indexedTable sql.Table
+}
+
+func (i *IndexedTableAccess) SetIndexLookup(ctx *sql.Context, lookup sql.IndexLookup) error {
+	resolvedTable, ok := i.ResolvedTable.Table.(sql.IndexableTable)
+	if !ok {
+		return ErrNoIndexableTable.New(i.ResolvedTable)
+	}
+
+	i.indexedTable = resolvedTable.WithIndexLookup(lookup)
+	return nil
+}
+
+func (i *IndexedTableAccess) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	if i.indexedTable == nil {
+		return nil, ErrIndexedTableAccessNotInitialized.New()
+	}
+
+	partIter, err := i.indexedTable.Partitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.NewTableIter(ctx, i.indexedTable, partIter), nil
+}
+
+func (i *IndexedTableAccess) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(i, len(children), 1)
+	}
+
+	resolvedTable, ok := children[0].(*ResolvedTable)
+	if !ok {
+		return nil, sql.ErrInvalidChildType.New(i, children[0], (*ResolvedTable)(nil))
+	}
+
+	return NewIndexedTable(resolvedTable), nil
+}
+
+func NewIndexedTable(resolvedTable *ResolvedTable) *IndexedTableAccess {
+	return &IndexedTableAccess{
+		ResolvedTable: resolvedTable,
+	}
+}
+
+var _ sql.Node = (*IndexedTableAccess)(nil)

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -279,6 +279,7 @@ func joinRowIter(
 			cond:              cond,
 			mode:              mode,
 			secondaryRows:     cache,
+			rowSize:           len(left.Schema()) + len(right.Schema()),
 			dispose:           dispose,
 		}), nil
 	}
@@ -297,6 +298,7 @@ func joinRowIter(
 		cond:              cond,
 		mode:              mode,
 		secondaryRows:     cache,
+		rowSize:           len(left.Schema()) + len(right.Schema()),
 		dispose:           dispose,
 	}), nil
 }
@@ -496,13 +498,7 @@ func (i *joinIter) Next() (sql.Row, error) {
 // buildRow builds the resulting row using the rows from the primary and
 // secondary branches depending on the join type.
 func (i *joinIter) buildRow(primary, secondary sql.Row) sql.Row {
-	var row sql.Row
-	if i.rowSize > 0 {
-		row = make(sql.Row, i.rowSize)
-	} else {
-		row = make(sql.Row, len(primary)+len(secondary))
-		i.rowSize = len(row)
-	}
+	row := make(sql.Row, i.rowSize)
 
 	switch i.typ {
 	case JoinTypeRight:

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -480,13 +480,12 @@ func (i *joinIter) Next() (sql.Row, error) {
 		}
 
 		row := i.buildRow(primary, secondary)
-		v, err := i.cond.Eval(i.ctx, row)
+		matches, err := conditionIsTrue(i.ctx, row, i.cond)
 		if err != nil {
 			return nil, err
 		}
 
-		// comparisons with nil will return nil, not true or false
-		if v != true {
+		if !matches {
 			continue
 		}
 

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -51,7 +51,7 @@ func (j *InnerJoin) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (j *InnerJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	return joinRowIter(ctx, innerJoin, j.Left, j.Right, j.Cond)
+	return joinRowIter(ctx, JoinTypeInner, j.Left, j.Right, j.Cond)
 }
 
 // WithChildren implements the Node interface.
@@ -113,7 +113,7 @@ func (j *LeftJoin) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (j *LeftJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	return joinRowIter(ctx, leftJoin, j.Left, j.Right, j.Cond)
+	return joinRowIter(ctx, JoinTypeLeft, j.Left, j.Right, j.Cond)
 }
 
 // WithChildren implements the Node interface.
@@ -175,7 +175,7 @@ func (j *RightJoin) Resolved() bool {
 
 // RowIter implements the Node interface.
 func (j *RightJoin) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	return joinRowIter(ctx, rightJoin, j.Left, j.Right, j.Cond)
+	return joinRowIter(ctx, JoinTypeRight, j.Left, j.Right, j.Cond)
 }
 
 // WithChildren implements the Node interface.
@@ -208,21 +208,21 @@ func (j *RightJoin) Expressions() []sql.Expression {
 	return []sql.Expression{j.Cond}
 }
 
-type joinType byte
+type JoinType byte
 
 const (
-	innerJoin joinType = iota
-	leftJoin
-	rightJoin
+	JoinTypeInner JoinType = iota
+	JoinTypeLeft
+	JoinTypeRight
 )
 
-func (t joinType) String() string {
+func (t JoinType) String() string {
 	switch t {
-	case innerJoin:
+	case JoinTypeInner:
 		return "InnerJoin"
-	case leftJoin:
+	case JoinTypeLeft:
 		return "LeftJoin"
-	case rightJoin:
+	case JoinTypeRight:
 		return "RightJoin"
 	default:
 		return "INVALID"
@@ -231,7 +231,7 @@ func (t joinType) String() string {
 
 func joinRowIter(
 	ctx *sql.Context,
-	typ joinType,
+	typ JoinType,
 	left, right sql.Node,
 	cond sql.Expression,
 ) (sql.RowIter, error) {
@@ -265,7 +265,7 @@ func joinRowIter(
 	}
 
 	cache, dispose := ctx.Memory.NewRowsCache()
-	if typ == rightJoin {
+	if typ == JoinTypeRight {
 		r, err := right.RowIter(ctx)
 		if err != nil {
 			span.Finish()
@@ -322,7 +322,7 @@ const (
 
 // joinIter is a generic iterator for all join types.
 type joinIter struct {
-	typ               joinType
+	typ               JoinType
 	primary           sql.RowIter
 	secondaryProvider rowIterProvider
 	secondary         sql.RowIter
@@ -469,7 +469,7 @@ func (i *joinIter) Next() (sql.Row, error) {
 		secondary, err := i.loadSecondary()
 		if err != nil {
 			if err == io.EOF {
-				if !i.foundMatch && (i.typ == leftJoin || i.typ == rightJoin) {
+				if !i.foundMatch && (i.typ == JoinTypeLeft || i.typ == JoinTypeRight) {
 					return i.buildRow(primary, nil), nil
 				}
 				continue
@@ -505,7 +505,7 @@ func (i *joinIter) buildRow(primary, secondary sql.Row) sql.Row {
 	}
 
 	switch i.typ {
-	case rightJoin:
+	case JoinTypeRight:
 		copy(row, secondary)
 		copy(row[i.rowSize-len(primary):], primary)
 	default:

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -483,7 +483,8 @@ func (i *joinIter) Next() (sql.Row, error) {
 			return nil, err
 		}
 
-		if v == false {
+		// comparisons with nil will return nil, not true or false
+		if v != true {
 			continue
 		}
 

--- a/sql/plan/project.go
+++ b/sql/plan/project.go
@@ -114,14 +114,14 @@ func (i *iter) Next() (sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filterRow(i.ctx, i.p.Projections, childRow)
+	return projectRow(i.ctx, i.p.Projections, childRow)
 }
 
 func (i *iter) Close() error {
 	return i.childIter.Close()
 }
 
-func filterRow(
+func projectRow(
 	s *sql.Context,
 	expressions []sql.Expression,
 	row sql.Row,

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -45,4 +45,3 @@ func (t *ResolvedTable) WithChildren(children ...sql.Node) (sql.Node, error) {
 
 	return t, nil
 }
-

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -34,7 +34,7 @@ func (t *ResolvedTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		return nil, err
 	}
 
-	return sql.NewSpanIter(span, sql.NewTableIter(ctx, t.Table, partitions)), nil
+	return sql.NewSpanIter(span, sql.NewTableRowIter(ctx, t.Table, partitions)), nil
 }
 
 // WithChildren implements the Node interface.

--- a/sql/row.go
+++ b/sql/row.go
@@ -48,6 +48,12 @@ type RowIter interface {
 	Close() error
 }
 
+// RowIterProvider provides an interface for producing rows for a given expression.
+type IndexRowIterProvider interface {
+	// RowIter returns a row iterator for the expression given, typically an index lookup
+	RowIter(*Context, Expression) (RowIter, error)
+}
+
 // RowIterToRows converts a row iterator to a slice of rows.
 func RowIterToRows(i RowIter) ([]Row, error) {
 	var rows []Row

--- a/sql/row.go
+++ b/sql/row.go
@@ -48,12 +48,6 @@ type RowIter interface {
 	Close() error
 }
 
-// RowIterProvider provides an interface for producing rows for a given expression.
-type IndexRowIterProvider interface {
-	// RowIter returns a row iterator for the expression given, typically an index lookup
-	RowIter(*Context, Expression) (RowIter, error)
-}
-
 // RowIterToRows converts a row iterator to a slice of rows.
 func RowIterToRows(i RowIter) ([]Row, error) {
 	var rows []Row

--- a/sql/table_iter.go
+++ b/sql/table_iter.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// TableRowIter is an iterator over the partitions in a table.
 type TableRowIter struct {
 	ctx        *Context
 	table      Table
@@ -13,7 +14,8 @@ type TableRowIter struct {
 	rows       RowIter
 }
 
-func NewTableIter(ctx *Context, table Table, partitions PartitionIter) *TableRowIter {
+// NewTableRowIter returns a new iterator over the rows in the partitions of the table given.
+func NewTableRowIter(ctx *Context, table Table, partitions PartitionIter) *TableRowIter {
 	return &TableRowIter{ctx: ctx, table: table, partitions: partitions}
 }
 

--- a/sql/table_iter.go
+++ b/sql/table_iter.go
@@ -1,0 +1,73 @@
+package sql
+
+import (
+	"context"
+	"io"
+)
+
+type TableRowIter struct {
+	ctx        *Context
+	table      Table
+	partitions PartitionIter
+	partition  Partition
+	rows       RowIter
+}
+
+func NewTableIter(ctx *Context, table Table, partitions PartitionIter) *TableRowIter {
+	return &TableRowIter{ctx: ctx, table: table, partitions: partitions}
+}
+
+func (i *TableRowIter) Next() (Row, error) {
+	select {
+	case <-i.ctx.Done():
+		return nil, context.Canceled
+	default:
+	}
+
+	if i.partition == nil {
+		partition, err := i.partitions.Next()
+		if err != nil {
+			if err == io.EOF {
+				if e := i.partitions.Close(); e != nil {
+					return nil, e
+				}
+			}
+
+			return nil, err
+		}
+
+		i.partition = partition
+	}
+
+	if i.rows == nil {
+		rows, err := i.table.PartitionRows(i.ctx, i.partition)
+		if err != nil {
+			return nil, err
+		}
+
+		i.rows = rows
+	}
+
+	row, err := i.rows.Next()
+	if err != nil && err == io.EOF {
+		if err = i.rows.Close(); err != nil {
+			return nil, err
+		}
+
+		i.partition = nil
+		i.rows = nil
+		return i.Next()
+	}
+
+	return row, err
+}
+
+func (i *TableRowIter) Close() error {
+	if i.rows != nil {
+		if err := i.rows.Close(); err != nil {
+			_ = i.partitions.Close()
+			return err
+		}
+	}
+	return i.partitions.Close()
+}


### PR DESCRIPTION
Indexed joins for single-column indexes. Also:
* Standardized capitalization of keywords in engine tests
* Fixed some bugs in non-indexed join logic
* Refactored and renamed a few things

This PR exposes (but does not create) a bug in sort logic for float columns. One new test query fails sometimes on tests of parallel query execution, depending on the race outcome. I'll fix that in a separate PR.