### PR TITLE
Fixed a bug in drop table logic caused by variable shadowing. No test…

### DIFF
--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -153,7 +153,7 @@ func (d *DropTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		}
 		err = droppable.DropTable(ctx, tbl.Name())
 		if err != nil {
-			break
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
…s of this behavior because we don't have an easy way to make an operation like DropTable return an error in the in-memory database.

Signed-off-by: Zach Musgrave <zach@liquidata.co>