### PR TITLE
sql/{parse,plan}: Add support union parsing and execution.

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -813,6 +813,22 @@ var queries = []queryTest{
 		},
 	},
 	{
+		"SELECT i FROM mytable UNION SELECT i+10 FROM mytable;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}, {int64(11)}, {int64(12)}, {int64(13)}},
+	},
+	{
+		"SELECT i FROM mytable UNION DISTINCT SELECT i+10 FROM mytable;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}, {int64(11)}, {int64(12)}, {int64(13)}},
+	},
+	{
+		"SELECT i FROM mytable UNION SELECT i FROM mytable;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}, {int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
+		"SELECT i FROM mytable UNION DISTINCT SELECT i FROM mytable;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
 		`/*!40101 SET NAMES utf8 */`,
 		nil,
 	},

--- a/engine_test.go
+++ b/engine_test.go
@@ -829,6 +829,17 @@ var queries = []queryTest{
 		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
+		"SELECT i FROM mytable UNION SELECT s FROM mytable;",
+		[]sql.Row{
+			{"1"},
+			{"2"},
+			{"3"},
+			{"first row"},
+			{"second row"},
+			{"third row"},
+		},
+	},
+	{
 		`/*!40101 SET NAMES utf8 */`,
 		nil,
 	},

--- a/sql/analyzer/merge_union_schemas.go
+++ b/sql/analyzer/merge_union_schemas.go
@@ -1,0 +1,60 @@
+package analyzer
+
+import (
+	"reflect"
+
+	"gopkg.in/src-d/go-errors.v1"
+
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/src-d/go-mysql-server/sql/plan"
+)
+
+var (
+	// ErrUnionSchemasDifferentLength is returned when the two sides of a
+	// UNION do not have the same number of columns in their schemas.
+	ErrUnionSchemasDifferentLength = errors.NewKind(
+		"cannot union two queries whose schemas are different lengths; left has %d column(s) right has %d column(s).",
+	)
+)
+
+func mergeUnionSchemas(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
+	if !n.Resolved() {
+		return n, nil
+	}
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
+		if u, ok := n.(*plan.Union); ok {
+			ls, rs := u.Left.Schema(), u.Right.Schema()
+			if len(ls) != len(rs) {
+				return nil, ErrUnionSchemasDifferentLength.New(len(ls), len(rs))
+			}
+			les, res := make([]sql.Expression, len(ls)), make([]sql.Expression, len(rs))
+			hasdiff := false
+			for i := range ls {
+				les[i] = expression.NewGetFieldWithTable(i, ls[i].Type, ls[i].Source, ls[i].Name, ls[i].Nullable)
+				res[i] = expression.NewGetFieldWithTable(i, rs[i].Type, rs[i].Source, rs[i].Name, rs[i].Nullable)
+				if reflect.DeepEqual(ls[i].Type, rs[i].Type) {
+					continue
+				}
+				hasdiff = true
+
+				// TODO: Principled type coercion...
+				les[i] = expression.NewConvert(les[i], expression.ConvertToChar)
+				res[i] = expression.NewConvert(res[i], expression.ConvertToChar)
+
+				// Preserve schema names across the conversion.
+				les[i] = expression.NewAlias(les[i], ls[i].Name)
+				res[i] = expression.NewAlias(res[i], rs[i].Name)
+			}
+			if hasdiff {
+				return u.WithChildren(
+					plan.NewProject(les, u.Left),
+					plan.NewProject(res, u.Right),
+				)
+			} else {
+				return u, nil
+			}
+		}
+		return n, nil
+	})
+}

--- a/sql/analyzer/merge_union_schemas_test.go
+++ b/sql/analyzer/merge_union_schemas_test.go
@@ -1,0 +1,127 @@
+package analyzer
+
+import (
+	"errors"
+	"testing"
+
+        "github.com/stretchr/testify/require"
+
+        "github.com/src-d/go-mysql-server/sql"
+        "github.com/src-d/go-mysql-server/sql/expression"
+        "github.com/src-d/go-mysql-server/sql/plan"
+)
+
+func TestMergeUnionSchemas(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   sql.Node
+		out  sql.Node
+		err  error
+	}{
+		{
+			"Unresolved is unchanged",
+			plan.NewUnion(
+				plan.NewUnresolvedTable("mytable", ""),
+				plan.NewUnresolvedTable("mytable", ""),
+			),
+			plan.NewUnion(
+				plan.NewUnresolvedTable("mytable", ""),
+				plan.NewUnresolvedTable("mytable", ""),
+			),
+			nil,
+		},
+		{
+			"Matching Schemas is Unchanged",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int64(1), sql.Int64) },
+					plan.NewResolvedTable(dualTable),
+				),
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int64(3), sql.Int64) },
+					plan.NewResolvedTable(dualTable),
+				),
+			),
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int64(1), sql.Int64) },
+					plan.NewResolvedTable(dualTable),
+				),
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int64(3), sql.Int64) },
+					plan.NewResolvedTable(dualTable),
+				),
+			),
+			nil,
+		},
+		{
+			"Mismatched Lengths is error",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int64(1), sql.Int64) },
+					plan.NewResolvedTable(dualTable),
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewLiteral(int64(3), sql.Int64),
+						expression.NewLiteral(int64(6), sql.Int64),
+					},
+					plan.NewResolvedTable(dualTable),
+				),
+			),
+			nil,
+			errors.New("this is an error"),
+		},
+		{
+			"Mismatched Types Coerced to Strings",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int64(1), sql.Int64) },
+					plan.NewResolvedTable(dualTable),
+				),
+				plan.NewProject(
+					[]sql.Expression{ expression.NewLiteral(int32(3), sql.Int32) },
+					plan.NewResolvedTable(dualTable),
+				),
+			),
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewAlias(
+							expression.NewConvert(
+								expression.NewGetField(0, sql.Int64, "1", false), "char"), "1"),
+					},
+					plan.NewProject(
+						[]sql.Expression{ expression.NewLiteral(int64(1), sql.Int64) },
+						plan.NewResolvedTable(dualTable),
+					),
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewAlias(
+							expression.NewConvert(
+								expression.NewGetField(0, sql.Int32, "3", false), "char"), "3"),
+					},
+					plan.NewProject(
+						[]sql.Expression{ expression.NewLiteral(int32(3), sql.Int32) },
+						plan.NewResolvedTable(dualTable),
+					),
+				),
+			),
+			nil,
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			require := require.New(t)
+			out, err := mergeUnionSchemas(sql.NewEmptyContext(), nil, c.in)
+			if c.err == nil {
+				require.NoError(err)
+				require.NotNil(out)
+				require.Equal(c.out, out)
+			} else {
+				require.Error(err)
+			}
+		})
+	}
+}

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -16,6 +16,7 @@ var DefaultRules = []Rule{
 	{"resolve_star", resolveStar},
 	{"resolve_functions", resolveFunctions},
 	{"resolve_having", resolveHaving},
+	{"merge_union_schemas", mergeUnionSchemas},
 	{"reorder_aggregations", reorderAggregations},
 	{"reorder_projection", reorderProjection},
 	{"move_join_conds_to_filter", moveJoinConditionsToFilter},

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -213,8 +213,11 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 		memory.NewTable(
 			"mytable",
 			sql.Schema{
-				{Name: "foo", Source: "mytable"},
-				{Name: "bar", Source: "mytable"},
+				{Name: "foo",  Source: "mytable", Type: sql.Text},
+				{Name: "bar",  Source: "mytable", Type: sql.Int64},
+				{Name: "rab",  Source: "mytable", Type: sql.Text},
+				{Name: "zab",  Source: "mytable", Type: sql.Int64},
+				{Name: "quuz", Source: "mytable", Type: sql.Boolean},
 			},
 		),
 	)
@@ -246,8 +249,8 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 				),
 				plan.NewProject(
 					[]sql.Expression{
-						expression.NewGetField(0, sql.Text, "rab", false),
-						expression.NewGetField(1, sql.Int64, "zab", false),
+						expression.NewGetField(2, sql.Text, "rab", false),
+						expression.NewGetField(3, sql.Int64, "zab", false),
 					},
 					table,
 				),
@@ -261,14 +264,14 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 					[]sql.Expression{
 						expression.NewGetField(0, sql.Text, "bar", false),
 						expression.NewGetField(1, sql.Int64, "baz", false),
-						expression.NewGetField(2, sql.Boolean, "quuz", false),
+						expression.NewGetField(4, sql.Boolean, "quuz", false),
 					},
 					table,
 				),
 				plan.NewProject(
 					[]sql.Expression{
-						expression.NewGetField(0, sql.Text, "rab", false),
-						expression.NewGetField(1, sql.Int64, "zab", false),
+						expression.NewGetField(2, sql.Text, "rab", false),
+						expression.NewGetField(3, sql.Int64, "zab", false),
 					},
 					table,
 				),
@@ -287,9 +290,9 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 				),
 				plan.NewProject(
 					[]sql.Expression{
-						expression.NewGetField(0, sql.Text, "rab", false),
-						expression.NewGetField(1, sql.Int64, "zab", false),
-						expression.NewGetField(2, sql.Boolean, "quuz", false),
+						expression.NewGetField(2, sql.Text, "rab", false),
+						expression.NewGetField(3, sql.Int64, "zab", false),
+						expression.NewGetField(4, sql.Boolean, "quuz", false),
 					},
 					table,
 				),
@@ -308,8 +311,8 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 				),
 				plan.NewProject(
 					[]sql.Expression{
-						expression.NewGetField(0, sql.Text, "rab", false),
-						expression.NewGetField(1, sql.Boolean, "zab", false),
+						expression.NewGetField(2, sql.Text, "rab", false),
+						expression.NewGetField(3, sql.Boolean, "zab", false),
 					},
 					table,
 				),
@@ -330,8 +333,8 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 					),
 					plan.NewProject(
 						[]sql.Expression{
-							expression.NewGetField(0, sql.Text, "rab", false),
-							expression.NewGetField(1, sql.Boolean, "zab", false),
+							expression.NewGetField(2, sql.Text, "rab", false),
+							expression.NewGetField(3, sql.Boolean, "zab", false),
 						},
 						table,
 					),

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -208,6 +208,154 @@ func TestValidateSchemaSource(t *testing.T) {
 	}
 }
 
+func TestValidateUnionSchemasMatch(t *testing.T) {
+	table := plan.NewResolvedTable(
+		memory.NewTable(
+			"mytable",
+			sql.Schema{
+				{Name: "foo", Source: "mytable"},
+				{Name: "bar", Source: "mytable"},
+			},
+		),
+	)
+	testCases := []struct {
+		name string
+		node sql.Node
+		ok   bool
+	}{
+		{
+			"some random node",
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewGetField(0, sql.Text, "bar", false),
+					expression.NewGetField(1, sql.Int64, "baz", false),
+				},
+				table,
+			),
+			true,
+		},
+		{
+			"top-level union with matching schemas",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "bar", false),
+						expression.NewGetField(1, sql.Int64, "baz", false),
+					},
+					table,
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "rab", false),
+						expression.NewGetField(1, sql.Int64, "zab", false),
+					},
+					table,
+				),
+			),
+			true,
+		},
+		{
+			"top-level union with longer left schema",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "bar", false),
+						expression.NewGetField(1, sql.Int64, "baz", false),
+						expression.NewGetField(2, sql.Boolean, "quuz", false),
+					},
+					table,
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "rab", false),
+						expression.NewGetField(1, sql.Int64, "zab", false),
+					},
+					table,
+				),
+			),
+			false,
+		},
+		{
+			"top-level union with longer right schema",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "bar", false),
+						expression.NewGetField(1, sql.Int64, "baz", false),
+					},
+					table,
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "rab", false),
+						expression.NewGetField(1, sql.Int64, "zab", false),
+						expression.NewGetField(2, sql.Boolean, "quuz", false),
+					},
+					table,
+				),
+			),
+			false,
+		},
+		{
+			"top-level union with mismatched type in schema",
+			plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "bar", false),
+						expression.NewGetField(1, sql.Int64, "baz", false),
+					},
+					table,
+				),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewGetField(0, sql.Text, "rab", false),
+						expression.NewGetField(1, sql.Boolean, "zab", false),
+					},
+					table,
+				),
+			),
+			false,
+		},
+		{
+			"subquery union",
+			plan.NewSubqueryAlias(
+				"aliased",
+				plan.NewUnion(
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewGetField(0, sql.Text, "bar", false),
+							expression.NewGetField(1, sql.Int64, "baz", false),
+						},
+						table,
+					),
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewGetField(0, sql.Text, "rab", false),
+							expression.NewGetField(1, sql.Boolean, "zab", false),
+						},
+						table,
+					),
+				),
+			),
+			false,
+		},
+	}
+
+	rule := getValidationRule(validateUnionSchemasMatchRule)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			_, err := rule.Apply(sql.NewEmptyContext(), nil, tt.node)
+			if tt.ok {
+				require.NoError(err)
+			} else {
+				require.Error(err)
+				require.True(ErrUnionSchemasMatch.Is(err))
+			}
+		})
+	}
+}
+
 func TestValidateProjectTuples(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1527,6 +1527,60 @@ var fixtures = map[string]sql.Node{
 			plan.NewUnresolvedTable("dual", ""),
 		),
 	),
+	`SELECT 2 UNION SELECT 3 UNION SELECT 4` : plan.NewUnion(
+		plan.NewUnion(
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewUnresolvedTable("dual", ""),
+			),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewUnresolvedTable("dual", ""),
+			),
+		),
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+	),
+	`SELECT 2 UNION (SELECT 3 UNION SELECT 4)` : plan.NewUnion(
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+		plan.NewUnion(
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewUnresolvedTable("dual", ""),
+			),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewUnresolvedTable("dual", ""),
+			),
+		),
+	),
+	`SELECT 2 UNION ALL SELECT 3` : plan.NewUnion(
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+	),
+	`SELECT 2 UNION DISTINCT SELECT 3` : plan.NewDistinct(
+		plan.NewUnion(
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewUnresolvedTable("dual", ""),
+			),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewUnresolvedTable("dual", ""),
+			),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1507,6 +1507,26 @@ var fixtures = map[string]sql.Node{
 		`SELECT * FROM foo`,
 		true,
 	),
+	`SELECT 2 UNION SELECT 3` : plan.NewUnion(
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+	),
+	`(SELECT 2) UNION (SELECT 3)` : plan.NewUnion(
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+		plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+			plan.NewUnresolvedTable("dual", ""),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {

--- a/sql/plan/union.go
+++ b/sql/plan/union.go
@@ -19,7 +19,17 @@ func NewUnion(left, right sql.Node) *Union {
 }
 
 func (u *Union) Schema() sql.Schema {
-	return u.Left.Schema()
+	ls := u.Left.Schema()
+	rs := u.Right.Schema()
+	ret := make([]*sql.Column, len(ls))
+	for i := range ls {
+		c := *ls[i]
+		if i < len(rs) {
+			c.Nullable = ls[i].Nullable || rs[i].Nullable
+		}
+		ret[i] = &c
+	}
+	return ret
 }
 
 // RowIter implements the Node interface.

--- a/sql/plan/union.go
+++ b/sql/plan/union.go
@@ -1,0 +1,88 @@
+package plan
+
+import (
+	"io"
+
+	"github.com/src-d/go-mysql-server/sql"
+)
+
+// Union is a node that returns everything in Left and then everything in Right
+type Union struct {
+	BinaryNode
+}
+
+// NewUnion creates a new Union node with the given children.
+func NewUnion(left, right sql.Node) *Union {
+	return &Union{
+		BinaryNode: BinaryNode{Left: left, Right: right},
+	}
+}
+
+func (u *Union) Schema() sql.Schema {
+	return u.Left.Schema()
+}
+
+// RowIter implements the Node interface.
+func (u *Union) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.Union")
+	li, err := u.Left.RowIter(ctx)
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+	ui := &unionIter{
+		li,
+		func() (sql.RowIter, error) {
+			return u.Right.RowIter(ctx)
+		},
+	}
+	return sql.NewSpanIter(span, ui), nil
+}
+
+// WithChildren implements the Node interface.
+func (u *Union) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 2)
+	}
+	return NewUnion(children[0], children[1]), nil
+}
+
+func (u Union) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("Union")
+	_ = pr.WriteChildren(u.Left.String(), u.Right.String())
+	return pr.String()
+}
+
+type unionIter struct {
+	cur      sql.RowIter
+	nextIter func() (sql.RowIter, error)
+}
+
+func (ui *unionIter) Next() (sql.Row, error) {
+	res, err := ui.cur.Next()
+	if err == io.EOF {
+		if ui.nextIter == nil {
+			return nil, io.EOF
+		}
+		err = ui.cur.Close()
+		if err != nil {
+			return nil, err
+		}
+		ui.cur, err = ui.nextIter()
+		ui.nextIter = nil
+		if err != nil {
+			return nil, err
+		}
+		return ui.cur.Next()
+	}
+	return res, err
+}
+
+func (ui *unionIter) Close() error {
+	if ui.cur != nil {
+		return ui.cur.Close()
+	} else {
+		return nil
+	}
+}

--- a/sql/plan/union_test.go
+++ b/sql/plan/union_test.go
@@ -1,0 +1,89 @@
+package plan
+
+import (
+	"io"
+	"testing"
+
+	"github.com/src-d/go-mysql-server/memory"
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/src-d/go-mysql-server/sql/expression"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnion(t *testing.T) {
+	require := require.New(t)
+
+	childSchema := sql.Schema{
+		{Name: "name", Type: sql.Text, Nullable: true},
+		{Name: "email", Type: sql.Text, Nullable: true},
+	}
+	child := memory.NewTable("test", childSchema)
+	empty := memory.NewTable("empty", childSchema)
+
+	rows := []sql.Row{
+		sql.NewRow("john", "john@doe.com"),
+		sql.NewRow("jane", "jane@doe.com"),
+		sql.NewRow("john", "johnx@doe.com"),
+		sql.NewRow("martha", "marthax@doe.com"),
+		sql.NewRow("martha", "martha@doe.com"),
+	}
+
+	for _, r := range rows {
+		require.NoError(child.Insert(sql.NewEmptyContext(), r))
+	}
+
+	name := []sql.Expression{
+		expression.NewGetField(0, sql.Text, "name", true),
+	}
+
+	cases := []struct {
+		node     sql.Node
+		expected []string
+	}{
+		{
+			NewUnion(
+				NewProject(name, NewResolvedTable(child)),
+				NewProject(name, NewResolvedTable(child))),
+			[]string{
+				"john", "jane", "john", "martha", "martha",
+				"john", "jane", "john", "martha", "martha",
+			},
+		},
+		{
+			NewUnion(
+				NewProject(name, NewResolvedTable(empty)),
+				NewProject(name, NewResolvedTable(child))),
+			[]string{
+				"john", "jane", "john", "martha", "martha",
+			},
+		},
+		{
+			NewUnion(
+				NewProject(name, NewResolvedTable(child)),
+				NewProject(name, NewResolvedTable(empty))),
+			[]string{
+				"john", "jane", "john", "martha", "martha",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		iter, err := c.node.RowIter(sql.NewEmptyContext())
+		require.NoError(err)
+		require.NotNil(iter)
+
+		var results []string
+		for {
+			row, err := iter.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(err)
+			result, ok := row[0].(string)
+			require.True(ok, "first row column should be string, but is %T", row[0])
+			results = append(results, result)
+		}
+
+		require.Equal(c.expected, results)
+	}
+}


### PR DESCRIPTION
This is still partial. We need type coercion and schema validation to be done
in the analysis phase.