### PR TITLE
Exposed marshalling functions for types to allow for proper storage

### DIFF
--- a/sql/enumtype.go
+++ b/sql/enumtype.go
@@ -18,7 +18,10 @@ const (
 	/// An ENUM column can have a maximum of 65,535 distinct elements.
 )
 
-var ErrConvertingToEnum = errors.NewKind("value %v is not valid for this Enum")
+var (
+	ErrConvertingToEnum = errors.NewKind("value %v is not valid for this Enum")
+	ErrUnmarshallingEnum = errors.NewKind("value %v is not a marshalled value for this Enum")
+)
 
 // Comments with three slashes were taken directly from the linked documentation.
 
@@ -31,7 +34,9 @@ type EnumType interface {
 	Collation() Collation
 	ConvertToIndex(v interface{}) (int, error)
 	IndexOf(v string) int
+	Marshal(v interface{}) (int64, error)
 	NumberOfElements() uint16
+	Unmarshal(v int64) (string, error)
 	Values() []string
 }
 
@@ -272,9 +277,24 @@ func (t enumType) IndexOf(v string) int {
 	return -1
 }
 
+// Marshal takes a valid Enum value and returns it as an int64.
+func (t enumType) Marshal(v interface{}) (int64, error) {
+	i, err := t.ConvertToIndex(v)
+	return int64(i), err
+}
+
 // NumberOfElements returns the number of enumerations.
 func (t enumType) NumberOfElements() uint16 {
 	return uint16(len(t.indexToVal))
+}
+
+// Unmarshal takes a previously-marshalled value and returns it as a string.
+func (t enumType) Unmarshal(v int64) (string, error) {
+	str, found := t.At(int(v))
+	if !found {
+		return "", ErrUnmarshallingEnum.New(v)
+	}
+	return str, nil
 }
 
 // Values returns the elements, in order, of every enumeration.

--- a/sql/enumtype_test.go
+++ b/sql/enumtype_test.go
@@ -131,6 +131,15 @@ func TestEnumConvert(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, test.expectedVal, val)
+				if test.val != nil {
+					mar, err := typ.Marshal(test.val)
+					require.NoError(t, err)
+					umar, err := typ.Unmarshal(mar)
+					require.NoError(t, err)
+					cmp, err := typ.Compare(test.val, umar)
+					require.NoError(t, err)
+					assert.Equal(t, 0, cmp)
+				}
 			}
 		})
 	}

--- a/sql/settype.go
+++ b/sql/settype.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"fmt"
+	"math"
 	"math/bits"
 	"strings"
 
@@ -16,9 +17,10 @@ const (
 )
 
 var (
-	ErrConvertingToSet = errors.NewKind("value %v is not valid for this Set")
+	ErrConvertingToSet = errors.NewKind("value %v is not valid for this set")
 	ErrDuplicateEntrySet = errors.NewKind("duplicate entry: %v")
 	ErrInvalidSetValue = errors.NewKind("value %v was not found in the set")
+	ErrTooLargeForSet = errors.NewKind(`value "%v" is too large for this set`)
 )
 
 // Comments with three slashes were taken directly from the linked documentation.
@@ -29,7 +31,9 @@ type SetType interface {
 	Type
 	CharacterSet() CharacterSet
 	Collation() Collation
+	Marshal(v interface{}) (uint64, error)
 	NumberOfElements() uint16
+	Unmarshal(bits uint64) (string, error)
 	Values() []string
 }
 
@@ -101,11 +105,11 @@ func (t setType) Compare(a interface{}, b interface{}) (int, error) {
 		return res, nil
 	}
 
-	ai, err := t.ConvertToBits(a)
+	ai, err := t.Marshal(a)
 	if err != nil {
 		return 0, err
 	}
-	bi, err := t.ConvertToBits(b)
+	bi, err := t.Marshal(b)
 	if err != nil {
 		return 0, err
 	}
@@ -145,11 +149,10 @@ func (t setType) Convert(v interface{}) (interface{}, error) {
 	case int64:
 		return t.Convert(uint64(value))
 	case uint64:
-		if value >= t.upperBound() {
-			return nil, ErrConvertingToSet.New(v)
+		if value <= t.allValuesBitField() {
+			return t.convertBitFieldToString(value)
 		}
-		vals, _ := t.convertBitFieldToString(value)
-		return vals, nil
+		return nil, ErrConvertingToSet.New(v)
 	case float32:
 		return t.Convert(uint64(value))
 	case float64:
@@ -176,49 +179,6 @@ func (t setType) MustConvert(v interface{}) interface{} {
 		panic(err)
 	}
 	return value
-}
-
-// ConvertToBits is similar to Convert, except that it converts to the number representing the bits rather than the string.
-// Returns an error on nil.
-func (t setType) ConvertToBits(v interface{}) (uint64, error) {
-	switch value := v.(type) {
-	case int:
-		return t.ConvertToBits(uint64(value))
-	case uint:
-		return t.ConvertToBits(uint64(value))
-	case int8:
-		return t.ConvertToBits(uint64(value))
-	case uint8:
-		return t.ConvertToBits(uint64(value))
-	case int16:
-		return t.ConvertToBits(uint64(value))
-	case uint16:
-		return t.ConvertToBits(uint64(value))
-	case int32:
-		return t.ConvertToBits(uint64(value))
-	case uint32:
-		return t.ConvertToBits(uint64(value))
-	case int64:
-		return t.ConvertToBits(uint64(value))
-	case uint64:
-		if value < t.upperBound() {
-			return value, nil
-		}
-	case float32:
-		return t.ConvertToBits(uint64(value))
-	case float64:
-		return t.ConvertToBits(uint64(value))
-	case string:
-		bitField, err := t.convertStringToBitField(value)
-		if err != nil {
-			return uint64(0), err
-		}
-		return bitField, nil
-	case []byte:
-		return t.ConvertToBits(string(value))
-	}
-
-	return uint64(0), ErrConvertingToSet.New(v)
 }
 
 // Promote implements the Type interface.
@@ -268,9 +228,52 @@ func (t setType) Collation() Collation {
 	return t.collation
 }
 
+// Marshal takes a valid Set value and returns it as an uint64.
+func (t setType) Marshal(v interface{}) (uint64, error) {
+	switch value := v.(type) {
+	case int:
+		return t.Marshal(uint64(value))
+	case uint:
+		return t.Marshal(uint64(value))
+	case int8:
+		return t.Marshal(uint64(value))
+	case uint8:
+		return t.Marshal(uint64(value))
+	case int16:
+		return t.Marshal(uint64(value))
+	case uint16:
+		return t.Marshal(uint64(value))
+	case int32:
+		return t.Marshal(uint64(value))
+	case uint32:
+		return t.Marshal(uint64(value))
+	case int64:
+		return t.Marshal(uint64(value))
+	case uint64:
+		if value <= t.allValuesBitField() {
+			return value, nil
+		}
+	case float32:
+		return t.Marshal(uint64(value))
+	case float64:
+		return t.Marshal(uint64(value))
+	case string:
+		return t.convertStringToBitField(value)
+	case []byte:
+		return t.Marshal(string(value))
+	}
+
+	return uint64(0), ErrConvertingToSet.New(v)
+}
+
 // NumberOfElements returns the number of elements in this set.
 func (t setType) NumberOfElements() uint16 {
 	return uint16(len(t.valToBit))
+}
+
+// Unmarshal takes a previously-marshalled value and returns it as a string.
+func (t setType) Unmarshal(v uint64) (string, error) {
+	return t.convertBitFieldToString(v)
 }
 
 // Values returns all of the set's values in ascending order according to their corresponding bit value.
@@ -286,9 +289,13 @@ func (t setType) Values() []string {
 
 // allValuesBitField returns a bit field that references every value that the set contains.
 func (t setType) allValuesBitField() uint64 {
+	valCount := uint64(len(t.valToBit))
+	if valCount == 64 {
+		return math.MaxUint64
+	}
 	// A set with 3 values will have an upper bound of 8, or 0b1000.
 	// 8 - 1 == 7, and 7 is 0b0111, which would map to every value in the set.
-	return t.upperBound() - 1
+	return uint64(1 << valCount) - 1
 }
 
 // convertBitFieldToString converts the given bit field into the equivalent comma-delimited string.
@@ -296,6 +303,9 @@ func (t setType) convertBitFieldToString(bitField uint64) (string, error) {
 	strBuilder := strings.Builder{}
 	bitEdge := 64 - bits.LeadingZeros64(bitField)
 	writeCommas := false
+	if bitEdge > len(t.bitToVal) {
+		return "", ErrTooLargeForSet.New(bitField)
+	}
 	for i := 0; i < bitEdge; i++ {
 		bit := uint64(1 << uint64(i))
 		if bit & bitField != 0 {
@@ -336,9 +346,4 @@ func (t setType) convertStringToBitField(str string) (uint64, error) {
 		}
 	}
 	return bitField, nil
-}
-
-// upperBound returns the exclusive upper bound for valid numbers representing a bit collection.
-func (t setType) upperBound() uint64 {
-	return uint64(1 << uint64(len(t.valToBit)))
 }

--- a/sql/settype_test.go
+++ b/sql/settype_test.go
@@ -177,6 +177,35 @@ func TestSetConvert(t *testing.T) {
 	}
 }
 
+func TestSetMarshalMax(t *testing.T) {
+	vals := make([]string, 64)
+	for i := range vals {
+		vals[i] = strconv.Itoa(i)
+	}
+	typ, err := CreateSetType(vals, Collation_Default)
+	require.NoError(t, err)
+
+	tests := []string{
+		"",
+		"1",
+		"1,2",
+		"0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63",
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test), func(t *testing.T) {
+			bits, err := typ.Marshal(test)
+			require.NoError(t, err)
+			res1, err := typ.Unmarshal(bits)
+			require.NoError(t, err)
+			require.Equal(t, test, res1)
+			res2, err := typ.Convert(bits)
+			require.NoError(t, err)
+			require.Equal(t, test, res2)
+		})
+	}
+}
+
 func TestSetString(t *testing.T) {
 	tests := []struct {
 		vals []string

--- a/sql/timetype.go
+++ b/sql/timetype.go
@@ -28,6 +28,8 @@ var (
 // https://dev.mysql.com/doc/refman/8.0/en/time.html
 type TimeType interface {
 	Type
+	Marshal(v interface{}) (int64, error)
+	Unmarshal(v int64) string
 }
 
 type timespanType struct{}
@@ -206,6 +208,20 @@ func (t timespanType) Type() query.Type {
 // Zero implements Type interface.
 func (t timespanType) Zero() interface{} {
 	return "00:00:00"
+}
+
+// Marshal takes a valid Time value and returns it as an int64.
+func (t timespanType) Marshal(v interface{}) (int64, error) {
+	if ti, err := t.ConvertToTimespanImpl(v); err != nil {
+		return 0, err
+	} else {
+		return ti.AsMicroseconds(), nil
+	}
+}
+
+// Unmarshal takes a previously-marshalled value and returns it as a string.
+func (t timespanType) Unmarshal(v int64) string {
+	return microsecondsToTimespan(v).String()
 }
 
 // No built in for absolute values on int64

--- a/sql/timetype_test.go
+++ b/sql/timetype_test.go
@@ -70,6 +70,7 @@ func TestTimeConvert(t *testing.T) {
 		expectedVal interface{}
 		expectedErr bool
 	}{
+		{nil, nil, false},
 		{int8(-1), "-00:00:01", false},
 		{uint8(59), "00:00:59", false},
 		{"-1", "-00:00:01", false},
@@ -129,6 +130,14 @@ func TestTimeConvert(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, test.expectedVal, val)
+				if test.val != nil {
+					mar, err := Time.Marshal(test.val)
+					require.NoError(t, err)
+					umar := Time.Unmarshal(mar)
+					cmp, err := Time.Compare(test.val, umar)
+					require.NoError(t, err)
+					assert.Equal(t, 0, cmp)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The decimal library that we're using has marshalling functions, but they're not intended for our use case (allowing noms to sort values without type information, etc.). I thought about a few different ways to go about it, such as outputting a byte array similar to how you'd write an int64 into a byte array, but the exponent made that a bit more difficult.

In the end, instead of writing a more complicated marshalling function, I decided to just use the string representation, but to make it sortable by shifting up every value by the upper bound. So for a decimal type of with range (-9.9, 9.9), it becomes (0.1, 19.9). When the precision and scale aren't equal, I prepend a 0 to numbers that were originally negative, so that -1.5 (using the previous range) becomes 08.5, which can be char for char compared to 13.2 (originally 3.2).