### PR TITLE
Zachmu/as of

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -4706,7 +4706,12 @@ func newEngineWithParallelism(t *testing.T, parallelism int, tables map[string]s
 		}
 	}
 
-	db := memory.NewHistoryDatabase(revisions, revisions["2019-01-02"])
+	var db sql.Database
+	if len(revisions) > 0 {
+		db = memory.NewHistoryDatabase(revisions, revisions["2019-01-02"])
+	} else {
+		db = newDatabaseWithoutHistoryTables(tables)
+	}
 
 	db2 := memory.NewDatabase("foo")
 	db2.AddTable("other_table", tables["other_table"])

--- a/engine_test.go
+++ b/engine_test.go
@@ -240,6 +240,30 @@ var queries = []queryTest{
 		[]sql.Row{{int64(3)}},
 	},
 	{
+		"SELECT *  FROM myhistorytable AS OF '2019-01-01' AS foo ORDER BY i",
+		[]sql.Row{
+			{int64(1), "first row, 1"},
+			{int64(2), "second row, 1"},
+			{int64(3), "third row, 1"},
+		},
+	},
+	{
+		"SELECT *  FROM myhistorytable AS OF '2019-01-02' foo ORDER BY i",
+		[]sql.Row{
+			{int64(1), "first row, 2"},
+			{int64(2), "second row, 2"},
+			{int64(3), "third row, 2"},
+		},
+	},
+	{
+		"SELECT *  FROM myhistorytable ORDER BY i",
+		[]sql.Row{
+			{int64(1), "first row, 2"},
+			{int64(2), "second row, 2"},
+			{int64(3), "third row, 2"},
+		},
+	},
+	{
 		"SELECT substring(s, 2, 3) FROM mytable",
 		[]sql.Row{{"irs"}, {"eco"}, {"hir"}},
 	},
@@ -4675,9 +4699,9 @@ func allTestTables(t *testing.T, numPartitions int) map[string]sql.Table {
 
 	insertRows(
 		t, ht2,
-		sql.NewRow(int64(1), "first row, 1"),
-		sql.NewRow(int64(2), "second row, 1"),
-		sql.NewRow(int64(3), "third row, 1"),
+		sql.NewRow(int64(1), "first row, 2"),
+		sql.NewRow(int64(2), "second row, 2"),
+		sql.NewRow(int64(3), "third row, 2"),
 	)
 
 	tables["myhistorytable"] = memory.NewHistoryTable(map[interface{}]*memory.Table{

--- a/go.mod
+++ b/go.mod
@@ -20,13 +20,14 @@ require (
 	github.com/stretchr/testify v1.4.0
 	go.etcd.io/bbolt v1.3.3
 	golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 // indirect
+	google.golang.org/api v0.20.0
 	google.golang.org/appengine v1.6.5 // indirect
-	google.golang.org/grpc v1.25.1 // indirect
 	gopkg.in/src-d/go-errors.v1 v1.0.0
 	gopkg.in/yaml.v2 v2.2.4
 	vitess.io/vitess v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible
 )
 
-replace vitess.io/vitess => github.com/liquidata-inc/vitess v0.0.0-20200102230944-f3410911d61f
+//replace vitess.io/vitess => github.com/liquidata-inc/vitess v0.0.0-20200102230944-f3410911d61f
+replace vitess.io/vitess => ../vitess
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,13 @@ require (
 	github.com/stretchr/testify v1.4.0
 	go.etcd.io/bbolt v1.3.3
 	golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 // indirect
-	google.golang.org/api v0.20.0
 	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/grpc v1.27.0 // indirect
 	gopkg.in/src-d/go-errors.v1 v1.0.0
 	gopkg.in/yaml.v2 v2.2.4
 	vitess.io/vitess v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible
 )
 
-//replace vitess.io/vitess => github.com/liquidata-inc/vitess v0.0.0-20200102230944-f3410911d61f
-replace vitess.io/vitess => ../vitess
+replace vitess.io/vitess => github.com/liquidata-inc/vitess v0.0.0-20200313225518-1b933e06b424
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
+cloud.google.com/go v0.45.1 h1:lRi0CHyU+ytlvylOlFKKq0af6JncuyoRh1J+QJBqQx0=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
@@ -60,6 +61,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -101,6 +103,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v1.3.0 h1:tsg9qP3mjt1h4Roxp+M1paRjrVBfPSOpBuVclh6YluI=
@@ -285,6 +288,7 @@ github.com/z-division/go-zookeeper v0.0.0-20190128072838-6d7457066b9b/go.mod h1:
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -329,6 +333,7 @@ golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 h1:MlY3mEfbnWGmUi4rtHOtNnnnN
 golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -379,7 +384,10 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
+google.golang.org/api v0.9.0 h1:jbyannxz0XFD3zdjgrSUsaJbgpH4eTrkdhRChkHPfO8=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
+google.golang.org/api v0.20.0 h1:jz2KixHX7EcCPiQrySzPdnYT7DbINAypCqKZ1Z7GM40=
+google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -402,6 +410,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
+google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20150924051756-4e86f4367175/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -166,8 +165,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/krishicks/yaml-patch v0.0.10/go.mod h1:Sm5TchwZS6sm7RJoyg87tzxm2ZcKzdRE4Q7TjNhPrME=
-github.com/liquidata-inc/vitess v0.0.0-20200102230944-f3410911d61f h1:fqsJy7h3D3esm9tYSzU7LV6h2tfifdYTanPuDL5LJ1A=
-github.com/liquidata-inc/vitess v0.0.0-20200102230944-f3410911d61f/go.mod h1:vn/QvIl/1+N6+qjheejcLt8jmX2kQSQwFinzZuoY1VY=
+github.com/liquidata-inc/vitess v0.0.0-20200313225518-1b933e06b424 h1:EEeIf1m1zaJbneoy4tfB09W/Q99Tj6IlW/WJbY+W1EE=
+github.com/liquidata-inc/vitess v0.0.0-20200313225518-1b933e06b424/go.mod h1:vn/QvIl/1+N6+qjheejcLt8jmX2kQSQwFinzZuoY1VY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-runewidth v0.0.1/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -386,8 +385,6 @@ google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0 h1:jbyannxz0XFD3zdjgrSUsaJbgpH4eTrkdhRChkHPfO8=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
-google.golang.org/api v0.20.0 h1:jz2KixHX7EcCPiQrySzPdnYT7DbINAypCqKZ1Z7GM40=
-google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -408,8 +405,6 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
-google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
-google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/memory/database.go
+++ b/memory/database.go
@@ -66,6 +66,15 @@ func (db *HistoryDatabase) GetTableInsensitiveAsOf(ctx *sql.Context, tblName str
 	return database.GetTableInsensitive(ctx, tblName)
 }
 
+func (db *HistoryDatabase) GetTableNamesAsOf(ctx *sql.Context, time interface{}) ([]string, error) {
+	database := db.Revisions[time]
+	if database == nil {
+		return nil, fmt.Errorf("No database revision for time %v", time)
+	}
+
+	return database.GetTableNames(ctx)
+}
+
 func NewHistoryDatabase(revisions map[interface{}]*Database, current *Database) *HistoryDatabase {
 	return &HistoryDatabase{
 		Database:  *current,

--- a/memory/table.go
+++ b/memory/table.go
@@ -611,42 +611,6 @@ func (t *Table) IndexLookup() sql.IndexLookup {
 	return t.lookup
 }
 
-// HistoryTable is a test-only HistoricalTable implementation. It only supports exact lookups, not AS OF queries
-// between two revisions.
-type HistoryTable struct {
-	Table
-	Revisions map[interface{}]*Table
-}
-
-var _ sql.Table = (*HistoryTable)(nil)
-var _ sql.InsertableTable = (*HistoryTable)(nil)
-var _ sql.UpdatableTable = (*HistoryTable)(nil)
-var _ sql.DeletableTable = (*HistoryTable)(nil)
-var _ sql.ReplaceableTable = (*HistoryTable)(nil)
-var _ sql.FilteredTable = (*HistoryTable)(nil)
-var _ sql.ProjectedTable = (*HistoryTable)(nil)
-var _ sql.IndexableTable = (*HistoryTable)(nil)
-var _ sql.AlterableTable = (*HistoryTable)(nil)
-var _ sql.HistoricalTable = (*HistoryTable)(nil)
-
-func NewHistoryTable(revisions map[interface{}]*Table, current *Table) *HistoryTable {
-	return &HistoryTable{
-		Table:     *current,
-		Revisions: revisions,
-	}
-}
-
-func (t *HistoryTable) AsOfTime(ctx *sql.Context, time interface{}) (sql.Table, error) {
-	rev, ok := t.Revisions[time]
-	if !ok {
-		return nil, fmt.Errorf("no revision for time %v", time)
-	}
-	return &HistoryTable{
-		Table:     *rev,
-		Revisions: t.Revisions,
-	}, nil
-}
-
 type partitionIndexKeyValueIter struct {
 	table   *Table
 	iter    sql.PartitionIter

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -4,12 +4,9 @@ import (
 	"github.com/src-d/go-mysql-server/memory"
 	"github.com/src-d/go-mysql-server/sql"
 	"github.com/src-d/go-mysql-server/sql/plan"
-	"gopkg.in/src-d/go-errors.v1"
 )
 
 const dualTableName = "dual"
-
-var ErrAsOfNotSupported = errors.NewKind("AS OF not supported for table %s")
 
 var dualTable = func() sql.Table {
 	t := memory.NewTable(dualTableName, sql.Schema{
@@ -71,7 +68,7 @@ func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 
 				return plan.NewResolvedTable(hTable), nil
 			} else {
-				return nil, ErrAsOfNotSupported.New(name)
+				return nil, sql.ErrAsOfNotSupported.New(name)
 			}
 		}
 

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -38,40 +38,36 @@ func resolveTables(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 			db = a.Catalog.CurrentDatabase()
 		}
 
-		rt, err := a.Catalog.Table(db, name)
-		if err != nil {
-			if sql.ErrTableNotFound.Is(err) {
-				if name == dualTableName {
-					rt = dualTable
-					name = dualTableName
-
-					a.Log("table resolved: %q", t.Name())
-					return plan.NewResolvedTable(rt), nil
-				}
+		if t.AsOf != nil {
+			asOf, err := t.AsOf.Eval(ctx, nil)
+			if err != nil {
+				return nil, err
 			}
-			return nil, err
+
+			rt, err := a.Catalog.TableAsOf(ctx, db, name, asOf)
+			if err != nil {
+				return handleTableLookupFailure(err, name, a, t)
+			}
+
+			return plan.NewResolvedTable(rt), nil
+		}
+
+		rt, err := a.Catalog.Table(ctx, db, name)
+		if err != nil {
+			return handleTableLookupFailure(err, name, a, t)
 		}
 
 		a.Log("table resolved: %q", t.Name())
-
-		if t.AsOf != nil {
-			if historical, ok := rt.(sql.HistoricalTable); ok {
-				asOf, err := t.AsOf.Eval(ctx, nil)
-				if err != nil {
-					return nil, err
-				}
-
-				hTable, err := historical.AsOfTime(ctx, asOf)
-				if err != nil {
-					return nil, err
-				}
-
-				return plan.NewResolvedTable(hTable), nil
-			} else {
-				return nil, sql.ErrAsOfNotSupported.New(name)
-			}
-		}
-
 		return plan.NewResolvedTable(rt), nil
 	})
+}
+
+func handleTableLookupFailure(err error, tableName string, a *Analyzer, t *plan.UnresolvedTable) (sql.Node, error) {
+	if sql.ErrTableNotFound.Is(err) {
+		if tableName == dualTableName {
+			a.Log("table resolved: %q", t.Name())
+			return plan.NewResolvedTable(dualTable), nil
+		}
+	}
+	return nil, err
 }

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -1,4 +1,3 @@
-
 package analyzer
 
 import (

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -19,13 +19,12 @@ func TestResolveTables(t *testing.T) {
 	db := memory.NewDatabase("mydb")
 	db.AddTable("mytable", table)
 
-	historyTable := memory.NewHistoryTable (map[interface{}]*memory.Table{
-		"2019-01-01": table,
-	}, table)
-	db.AddTable("historyTable", historyTable)
+	versionedDb := memory.NewHistoryDatabase(map[interface{}]*memory.Database{
+		"2019-01-01": db,
+	}, db)
 
 	catalog := sql.NewCatalog()
-	catalog.AddDatabase(db)
+	catalog.AddDatabase(versionedDb)
 
 	a := NewBuilder(catalog).AddPostAnalyzeRule(f.Name, f.Apply).Build()
 
@@ -60,16 +59,10 @@ func TestResolveTables(t *testing.T) {
 
 	notAnalyzed = plan.NewUnresolvedTableAsOf("myTable", "", expression.NewLiteral("2019-01-01", sql.LongText))
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
-	require.Error(err)
-	require.True(sql.ErrAsOfNotSupported.Is(err))
-
-	notAnalyzed = plan.NewUnresolvedTableAsOf("historyTable", "", expression.NewLiteral("2019-01-01", sql.LongText))
-	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.NoError(err)
-	asOfTable, err := historyTable.AsOfTime(sql.NewEmptyContext(), "2019-01-01")
-	require.Equal(plan.NewResolvedTable(asOfTable), analyzed)
+	require.Equal(plan.NewResolvedTable(table), analyzed)
 
-	notAnalyzed = plan.NewUnresolvedTableAsOf("historyTable", "", expression.NewLiteral("2019-01-02", sql.LongText))
+	notAnalyzed = plan.NewUnresolvedTableAsOf("myTable", "", expression.NewLiteral("2019-01-02", sql.LongText))
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.Error(err)
 }

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -62,7 +62,7 @@ func TestResolveTables(t *testing.T) {
 	notAnalyzed = plan.NewUnresolvedTableAsOf("myTable", "", expression.NewLiteral("2019-01-01", sql.LongText))
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)
 	require.Error(err)
-	require.True(ErrAsOfNotSupported.Is(err))
+	require.True(sql.ErrAsOfNotSupported.Is(err))
 
 	notAnalyzed = plan.NewUnresolvedTableAsOf("historyTable", "", expression.NewLiteral("2019-01-01", sql.LongText))
 	analyzed, err = f.Apply(sql.NewEmptyContext(), a, notAnalyzed)

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestResolveTables(t *testing.T) {
 	require := require.New(t)
-
 	f := getRule("resolve_tables")
 
 	table := memory.NewTable("mytable", sql.Schema{{Name: "i", Type: sql.Int32}})

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -92,10 +91,10 @@ func (c *Catalog) Database(db string) (Database, error) {
 }
 
 // Table returns the table in the given database with the given name.
-func (c *Catalog) Table(db, table string) (Table, error) {
+func (c *Catalog) Table(ctx *Context, db, table string) (Table, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.dbs.Table(context.TODO(), db, table, c.IndexRegistry)
+	return c.dbs.Table(ctx, db, table, c.IndexRegistry)
 }
 
 // TableAsOf returns the table in the given database with the given name, as it existed at the time given. The database
@@ -134,7 +133,7 @@ func (d *Databases) Add(db Database) {
 }
 
 // Table returns the Table with the given name if it exists.
-func (d Databases) Table(ctx context.Context, dbName string, tableName string, idxReg *IndexRegistry) (Table, error) {
+func (d Databases) Table(ctx *Context, dbName string, tableName string, idxReg *IndexRegistry) (Table, error) {
 	db, err := d.Database(dbName)
 	if err != nil {
 		return nil, err
@@ -151,7 +150,7 @@ func (d Databases) Table(ctx context.Context, dbName string, tableName string, i
 	return tbl, nil
 }
 
-func suggestSimilarTables(db Database, ctx context.Context, tableName string) error {
+func suggestSimilarTables(db Database, ctx *Context, tableName string) error {
 	tableNames, err := db.GetTableNames(ctx)
 	if err != nil {
 		return err

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -176,10 +176,20 @@ func (d Databases) TableAsOf(ctx *Context, dbName string, tableName string, time
 	if err != nil {
 		return nil, err
 	} else if !ok {
-		return nil, suggestSimilarTables(db, ctx, tableName)
+		return nil, suggestSimilarTablesAsOf(versionedDb, ctx, tableName, time)
 	}
 
 	return tbl, nil
+}
+
+func suggestSimilarTablesAsOf(db VersionedDatabase, ctx *Context, tableName string, time interface{}) error {
+	tableNames, err := db.GetTableNamesAsOf(ctx, time)
+	if err != nil {
+		return err
+	}
+
+	similar := similartext.Find(tableNames, tableName)
+	return ErrTableNotFound.New(tableName + similar)
 }
 
 // LockTable adds a lock for the given table and session client. It is assumed

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -160,7 +160,9 @@ func suggestSimilarTables(db Database, ctx *Context, tableName string) error {
 	return ErrTableNotFound.New(tableName + similar)
 }
 
-func (d Databases) TableAsOf(ctx *Context, dbName string, tableName string, time interface{}) (Table, error) {
+// TableAsOf returns the table with the name given at the time given, if it existed. The database named must implement
+// sql.VersionedDatabase or an error is returned.
+func (d Databases) TableAsOf(ctx *Context, dbName string, tableName string, asOf interface{}) (Table, error) {
 	db, err := d.Database(dbName)
 	if err != nil {
 		return nil, err
@@ -171,12 +173,12 @@ func (d Databases) TableAsOf(ctx *Context, dbName string, tableName string, time
 		return nil, ErrAsOfNotSupported.New(tableName)
 	}
 
-	tbl, ok, err := versionedDb.GetTableInsensitiveAsOf(ctx, tableName, time)
+	tbl, ok, err := versionedDb.GetTableInsensitiveAsOf(ctx, tableName, asOf)
 
 	if err != nil {
 		return nil, err
 	} else if !ok {
-		return nil, suggestSimilarTablesAsOf(versionedDb, ctx, tableName, time)
+		return nil, suggestSimilarTablesAsOf(versionedDb, ctx, tableName, asOf)
 	}
 
 	return tbl, nil

--- a/sql/catalog_test.go
+++ b/sql/catalog_test.go
@@ -62,30 +62,31 @@ func TestCatalogTable(t *testing.T) {
 	require := require.New(t)
 
 	c := sql.NewCatalog()
+	ctx := sql.NewEmptyContext()
 
-	table, err := c.Table("foo", "bar")
+	table, err := c.Table(ctx,"foo", "bar")
 	require.EqualError(err, "database not found: foo")
 	require.Nil(table)
 
 	db := memory.NewDatabase("foo")
 	c.AddDatabase(db)
 
-	table, err = c.Table("foo", "bar")
+	table, err = c.Table(ctx,"foo", "bar")
 	require.EqualError(err, "table not found: bar")
 	require.Nil(table)
 
 	mytable := memory.NewTable("bar", nil)
 	db.AddTable("bar", mytable)
 
-	table, err = c.Table("foo", "baz")
+	table, err = c.Table(ctx,"foo", "baz")
 	require.EqualError(err, "table not found: baz, maybe you mean bar?")
 	require.Nil(table)
 
-	table, err = c.Table("foo", "bar")
+	table, err = c.Table(ctx,"foo", "bar")
 	require.NoError(err)
 	require.Equal(mytable, table)
 
-	table, err = c.Table("foo", "BAR")
+	table, err = c.Table(ctx,"foo", "BAR")
 	require.NoError(err)
 	require.Equal(mytable, table)
 }

--- a/sql/core.go
+++ b/sql/core.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"github.com/src-d/go-mysql-server/sql"
 	"gopkg.in/src-d/go-errors.v1"
 	"io"
 	"math"
@@ -208,6 +209,13 @@ type IndexableTable interface {
 	WithIndexLookup(IndexLookup) Table
 	IndexLookup() IndexLookup
 	IndexKeyValues(*Context, []string) (PartitionIndexKeyValueIter, error)
+}
+
+// HistoricalTable is one that can return the values of rows at different times in the past. Integrators can choose
+// which types of expressions to accept.
+type HistoricalTable interface {
+	Table
+	AsOfTime(ctx *sql.Context, time interface{}) (Table, error)
 }
 
 // InsertableTable is a table that can process insertion of new rows.

--- a/sql/core.go
+++ b/sql/core.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"gopkg.in/src-d/go-errors.v1"
 	"io"
@@ -210,13 +209,6 @@ type IndexableTable interface {
 	IndexKeyValues(*Context, []string) (PartitionIndexKeyValueIter, error)
 }
 
-// HistoricalTable is one that can return the values of rows at different times in the past. Integrators can choose
-// which types of expressions to accept.
-type HistoricalTable interface {
-	Table
-	AsOfTime(ctx *Context, time interface{}) (Table, error)
-}
-
 // InsertableTable is a table that can process insertion of new rows.
 type InsertableTable interface {
 	// Inserter returns an Inserter for this table. The Inserter will get one call to Insert() for each row to be
@@ -300,10 +292,10 @@ type Database interface {
 	// (case-sensitive matches) first.  If no exact matches are found then any table matching the name case insensitively
 	// should be returned.  If there is more than one table that matches a case insensitive comparison the resolution
 	// strategy is not defined.
-	GetTableInsensitive(ctx context.Context, tblName string) (Table, bool, error)
+	GetTableInsensitive(ctx *Context, tblName string) (Table, bool, error)
 
 	// GetTableNames returns the table names of every table in the database
-	GetTableNames(ctx context.Context) ([]string, error)
+	GetTableNames(ctx *Context) ([]string, error)
 }
 
 // VersionedDatabase is a Database that can return tables as they existed at different points in time. The engine
@@ -314,7 +306,7 @@ type VersionedDatabase interface {
 	// GetTableInsensitiveAsOf retrieves a table by its case-insensitive name with the same semantics as
 	// Database.GetTableInsensitive, but at a particular revision of the database. Implementors must choose which types
 	// of expressions to accept as revision names.
-	GetTableInsensitiveAsOf(ctx context.Context, tblName string, time interface{}) (Table, bool, error)
+	GetTableInsensitiveAsOf(ctx *Context, tblName string, time interface{}) (Table, bool, error)
 }
 
 // GetTableInsensitive implements a case insensitive map lookup for tables keyed off of the table name.
@@ -360,7 +352,7 @@ func GetTableNameInsensitive(tblName string, tableNames []string) (string, bool)
 
 // DBTableIter iterates over all tables returned by db.GetTableNames() calling cb for each one until all tables have
 // been processed, or an error is returned from the callback, or the cont flag is false when returned from the callback.
-func DBTableIter(ctx context.Context, db Database, cb func(Table) (cont bool, err error)) error {
+func DBTableIter(ctx *Context, db Database, cb func(Table) (cont bool, err error)) error {
 	names, err := db.GetTableNames(ctx)
 
 	if err != nil {

--- a/sql/core.go
+++ b/sql/core.go
@@ -306,10 +306,11 @@ type VersionedDatabase interface {
 	// GetTableInsensitiveAsOf retrieves a table by its case-insensitive name with the same semantics as
 	// Database.GetTableInsensitive, but at a particular revision of the database. Implementors must choose which types
 	// of expressions to accept as revision names.
-	GetTableInsensitiveAsOf(ctx *Context, tblName string, time interface{}) (Table, bool, error)
+	GetTableInsensitiveAsOf(ctx *Context, tblName string, asOf interface{}) (Table, bool, error)
 
-	// GetTableNamesAsOf returns the table names of every table in the database as of the revision given
-	GetTableNamesAsOf(ctx *Context, time interface{}) ([]string, error)
+	// GetTableNamesAsOf returns the table names of every table in the database as of the revision given. Implementors
+	// must choose which types of expressions to accept as revision names.
+	GetTableNamesAsOf(ctx *Context, asOf interface{}) ([]string, error)
 }
 
 // GetTableInsensitive implements a case insensitive map lookup for tables keyed off of the table name.

--- a/sql/core.go
+++ b/sql/core.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"github.com/src-d/go-mysql-server/sql"
 	"gopkg.in/src-d/go-errors.v1"
 	"io"
 	"math"
@@ -215,7 +214,7 @@ type IndexableTable interface {
 // which types of expressions to accept.
 type HistoricalTable interface {
 	Table
-	AsOfTime(ctx *sql.Context, time interface{}) (Table, error)
+	AsOfTime(ctx *Context, time interface{}) (Table, error)
 }
 
 // InsertableTable is a table that can process insertion of new rows.

--- a/sql/core.go
+++ b/sql/core.go
@@ -307,6 +307,9 @@ type VersionedDatabase interface {
 	// Database.GetTableInsensitive, but at a particular revision of the database. Implementors must choose which types
 	// of expressions to accept as revision names.
 	GetTableInsensitiveAsOf(ctx *Context, tblName string, time interface{}) (Table, bool, error)
+
+	// GetTableNamesAsOf returns the table names of every table in the database as of the revision given
+	GetTableNamesAsOf(ctx *Context, time interface{}) ([]string, error)
 }
 
 // GetTableInsensitive implements a case insensitive map lookup for tables keyed off of the table name.

--- a/sql/core.go
+++ b/sql/core.go
@@ -296,14 +296,25 @@ type RowUpdater interface {
 type Database interface {
 	Nameable
 
-	// GetTableInsensitive retrieves a table by it's name where capitalization does not matter.  Implementations should
-	// look for exact matches first.  If no exact matches are found then any table matching the name case insensitively
+	// GetTableInsensitive retrieves a table by its case insensitive name.  Implementations should look for exact
+	// (case-sensitive matches) first.  If no exact matches are found then any table matching the name case insensitively
 	// should be returned.  If there is more than one table that matches a case insensitive comparison the resolution
 	// strategy is not defined.
 	GetTableInsensitive(ctx context.Context, tblName string) (Table, bool, error)
 
 	// GetTableNames returns the table names of every table in the database
 	GetTableNames(ctx context.Context) ([]string, error)
+}
+
+// VersionedDatabase is a Database that can return tables as they existed at different points in time. The engine
+// supports queries on historical table data via the AS OF construct introduced in SQL 2011.
+type VersionedDatabase interface {
+	Database
+
+	// GetTableInsensitiveAsOf retrieves a table by its case-insensitive name with the same semantics as
+	// Database.GetTableInsensitive, but at a particular revision of the database. Implementors must choose which types
+	// of expressions to accept as revision names.
+	GetTableInsensitiveAsOf(ctx context.Context, tblName string, time interface{}) (Table, bool, error)
 }
 
 // GetTableInsensitive implements a case insensitive map lookup for tables keyed off of the table name.

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -252,7 +251,7 @@ func TestExpressionsWithIndexes(t *testing.T) {
 }
 
 func TestLoadIndexes(t *testing.T) {
-	ctx := context.Background()
+	ctx := NewEmptyContext()
 	require := require.New(t)
 
 	d1 := &loadDriver{id: "d1", indexes: []Index{
@@ -306,7 +305,7 @@ func TestLoadIndexes(t *testing.T) {
 }
 
 func TestLoadOutdatedIndexes(t *testing.T) {
-	ctx := context.Background()
+	ctx := NewEmptyContext()
 	require := require.New(t)
 
 	d := &loadDriver{id: "d1", indexes: []Index{
@@ -351,11 +350,11 @@ type dummyDB struct {
 
 func (d dummyDB) Name() string             { return d.name }
 func (d dummyDB) Tables() map[string]Table { return d.tables }
-func (d dummyDB) GetTableInsensitive(ctx context.Context, tblName string) (Table, bool, error) {
+func (d dummyDB) GetTableInsensitive(ctx *Context, tblName string) (Table, bool, error) {
 	tbl, ok := GetTableInsensitive(tblName, d.tables)
 	return tbl, ok, nil
 }
-func (d dummyDB) GetTableNames(ctx context.Context) ([]string, error) {
+func (d dummyDB) GetTableNames(ctx *Context) ([]string, error) {
 	tblNames := make([]string, 0, len(d.tables))
 	for k := range d.tables {
 		tblNames = append(tblNames, k)

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -2,7 +2,6 @@ package sql
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -158,7 +157,7 @@ var schemataSchema = Schema{
 }
 
 func tablesRowIter(cat *Catalog) RowIter {
-	ctx := context.TODO()
+	ctx := NewEmptyContext()
 
 	var rows []Row
 	for _, db := range cat.AllDatabases() {
@@ -209,7 +208,7 @@ func tablesRowIter(cat *Catalog) RowIter {
 }
 
 func columnsRowIter(cat *Catalog) RowIter {
-	ctx := context.TODO()
+	ctx := NewEmptyContext()
 
 	var rows []Row
 	for _, db := range cat.AllDatabases() {
@@ -328,12 +327,12 @@ func (db *informationSchemaDatabase) Name() string { return db.name }
 // Tables implements the sql.Database interface.
 func (db *informationSchemaDatabase) Tables() map[string]Table { return db.tables }
 
-func (db *informationSchemaDatabase) GetTableInsensitive(ctx context.Context, tblName string) (Table, bool, error) {
+func (db *informationSchemaDatabase) GetTableInsensitive(ctx *Context, tblName string) (Table, bool, error) {
 	tbl, ok := GetTableInsensitive(tblName, db.tables)
 	return tbl, ok, nil
 }
 
-func (db *informationSchemaDatabase) GetTableNames(ctx context.Context) ([]string, error) {
+func (db *informationSchemaDatabase) GetTableNames(ctx *Context) ([]string, error) {
 	tblNames := make([]string, 0, len(db.tables))
 	for k := range db.tables {
 		tblNames = append(tblNames, k)

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -798,7 +798,17 @@ func tableExprToTable(
 		// TODO: Add support for qualifier.
 		switch e := t.Expr.(type) {
 		case sqlparser.TableName:
-			node := plan.NewUnresolvedTable(e.Name.String(), e.Qualifier.String())
+			var node *plan.UnresolvedTable
+			if t.AsOf != nil {
+				asOfExpr, err := exprToExpression(ctx, t.AsOf.Time)
+				if err != nil {
+					return nil, err
+				}
+				node = plan.NewUnresolvedTableAsOf(e.Name.String(), e.Qualifier.String(), asOfExpr)
+			} else {
+				node = plan.NewUnresolvedTable(e.Name.String(), e.Qualifier.String())
+			}
+
 			if !t.As.IsEmpty() {
 				return plan.NewTableAlias(t.As.String(), node), nil
 			}

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -306,6 +306,17 @@ var fixtures = map[string]sql.Node{
 		},
 		plan.NewUnresolvedTable("foo", ""),
 	),
+	`SELECT foo AS bar FROM foo AS OF '2019-01-01' AS baz;`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewAlias(
+				expression.NewUnresolvedColumn("foo"),
+				"bar",
+			),
+		},
+		plan.NewTableAlias("baz",
+			plan.NewUnresolvedTableAsOf("foo", "",
+				expression.NewLiteral("2019-01-01", sql.LongText))),
+	),
 	`SELECT foo, bar FROM foo WHERE foo = bar;`: plan.NewProject(
 		[]sql.Expression{
 			expression.NewUnresolvedColumn("foo"),

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -79,11 +78,12 @@ func (n *ShowIndexes) Schema() sql.Schema {
 func (n *ShowIndexes) Children() []sql.Node { return nil }
 
 // RowIter implements the Node interface.
-func (n *ShowIndexes) RowIter(*sql.Context) (sql.RowIter, error) {
+func (n *ShowIndexes) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return &showIndexesIter{
 		db:       n.db,
 		table:    n.Table,
 		registry: n.Registry,
+		ctx:      ctx,
 	}, nil
 }
 
@@ -93,6 +93,7 @@ type showIndexesIter struct {
 	registry *sql.IndexRegistry
 
 	idxs *indexesToShow
+	ctx  *sql.Context
 }
 
 func (i *showIndexesIter) Next() (sql.Row, error) {
@@ -116,7 +117,7 @@ func (i *showIndexesIter) Next() (sql.Row, error) {
 		visible  string
 	)
 	columnName, expression := "NULL", show.expression
-	tbl, _, err := i.db.GetTableInsensitive(context.TODO(), i.table)
+	tbl, _, err := i.db.GetTableInsensitive(i.ctx, i.table)
 
 	if err != nil {
 		return nil, err

--- a/sql/plan/unresolved.go
+++ b/sql/plan/unresolved.go
@@ -14,7 +14,7 @@ var ErrUnresolvedTable = errors.NewKind("unresolved table")
 type UnresolvedTable struct {
 	name     string
 	Database string
-	asOf     sql.Expression
+	AsOf     sql.Expression
 }
 
 // NewUnresolvedTable creates a new Unresolved table.

--- a/sql/plan/unresolved.go
+++ b/sql/plan/unresolved.go
@@ -14,11 +14,17 @@ var ErrUnresolvedTable = errors.NewKind("unresolved table")
 type UnresolvedTable struct {
 	name     string
 	Database string
+	asOf     sql.Expression
 }
 
 // NewUnresolvedTable creates a new Unresolved table.
 func NewUnresolvedTable(name, db string) *UnresolvedTable {
-	return &UnresolvedTable{name, db}
+	return &UnresolvedTable{name, db, nil}
+}
+
+// NewUnresolvedTableAsOf creates a new Unresolved table with an AS OF expression.
+func NewUnresolvedTableAsOf(name, db string, asOf sql.Expression) *UnresolvedTable {
+	return &UnresolvedTable{name, db, asOf}
 }
 
 // Name implements the Nameable interface.

--- a/sql/unresolved_database.go
+++ b/sql/unresolved_database.go
@@ -1,7 +1,5 @@
 package sql
 
-import "context"
-
 var _ Database = UnresolvedDatabase("")
 
 // UnresolvedDatabase is a database which has not been resolved yet.
@@ -17,10 +15,10 @@ func (UnresolvedDatabase) Tables() map[string]Table {
 	return make(map[string]Table)
 }
 
-func (UnresolvedDatabase) GetTableInsensitive(ctx context.Context, tblName string) (Table, bool, error) {
+func (UnresolvedDatabase) GetTableInsensitive(ctx *Context, tblName string) (Table, bool, error) {
 	return nil, false, nil
 }
 
-func (UnresolvedDatabase) GetTableNames(ctx context.Context) ([]string, error) {
+func (UnresolvedDatabase) GetTableNames(ctx *Context) ([]string, error) {
 	return []string{}, nil
 }


### PR DESCRIPTION
AS OF implementation.

This change also removes context.Context references from the core.go interfaces, replacing them with sql.Context to be consistent.