### PR TITLE
per connection state

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -170,7 +170,3 @@ func (e *Engine) AddDatabase(db sql.Database) {
 	e.Catalog.AddDatabase(db)
 }
 
-// Init performs all the initialization requirements for the engine to work.
-func (e *Engine) Init() error {
-	return nil // e.Catalog.LoadIndexes(e.Catalog.AllDatabases())
-}

--- a/engine.go
+++ b/engine.go
@@ -172,5 +172,5 @@ func (e *Engine) AddDatabase(db sql.Database) {
 
 // Init performs all the initialization requirements for the engine to work.
 func (e *Engine) Init() error {
-	return e.Catalog.LoadIndexes(e.Catalog.AllDatabases())
+	return nil // e.Catalog.LoadIndexes(e.Catalog.AllDatabases())
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -4802,7 +4802,7 @@ func newEngineWithParallelism(t *testing.T, parallelism int, tables map[string]*
 	}
 
 	engine := sqle.New(catalog, a, new(sqle.Config))
-	require.NoError(t, idxReg.LoadIndexes(engine.Catalog.AllDatabases()))
+	require.NoError(t, idxReg.LoadIndexes(sql.NewEmptyContext(), engine.Catalog.AllDatabases()))
 
 	return engine, idxReg
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package sqle_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -11,7 +12,7 @@ import (
 
 func Example() {
 	e := sqle.NewDefault()
-	ctx := sql.NewEmptyContext()
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(sql.NewIndexRegistry()), sql.WithViewRegistry(sql.NewViewRegistry()))
 
 	// Create a test memory database and register it to the default engine.
 	e.AddDatabase(createTestDatabase())

--- a/memory/index_driver.go
+++ b/memory/index_driver.go
@@ -23,7 +23,7 @@ func (d *TestIndexDriver) ID() string {
 	return IndexDriverId
 }
 
-func (d *TestIndexDriver) LoadAll(db, table string) ([]sql.Index, error) {
+func (d *TestIndexDriver) LoadAll(ctx *sql.Context, db, table string) ([]sql.Index, error) {
 	if d.db != db {
 		return nil, nil
 	}

--- a/server/context.go
+++ b/server/context.go
@@ -10,16 +10,16 @@ import (
 )
 
 // SessionBuilder creates sessions given a MySQL connection and a server address.
-type SessionBuilder func(conn *mysql.Conn, addr string) sql.Session
+type SessionBuilder func(conn *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry)
 
 // DoneFunc is a function that must be executed when the session is used and
 // it can be disposed.
 type DoneFunc func()
 
 // DefaultSessionBuilder is a SessionBuilder that returns a base session.
-func DefaultSessionBuilder(c *mysql.Conn, addr string) sql.Session {
+func DefaultSessionBuilder(c *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry) {
 	client := c.RemoteAddr().String()
-	return sql.NewSession(addr, client, c.User, c.ConnectionID)
+	return sql.NewSession(addr, client, c.User, c.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry()
 }
 
 // SessionManager is in charge of creating new sessions for the given
@@ -32,6 +32,8 @@ type SessionManager struct {
 	mu       *sync.Mutex
 	builder  SessionBuilder
 	sessions map[uint32]sql.Session
+	idxRegs  map[uint32]*sql.IndexRegistry
+	viewRegs map[uint32]*sql.ViewRegistry
 	pid      uint64
 }
 
@@ -49,6 +51,8 @@ func NewSessionManager(
 		mu:       new(sync.Mutex),
 		builder:  builder,
 		sessions: make(map[uint32]sql.Session),
+		idxRegs: make(map[uint32]*sql.IndexRegistry),
+		viewRegs: make(map[uint32]*sql.ViewRegistry),
 	}
 }
 
@@ -63,7 +67,7 @@ func (s *SessionManager) nextPid() uint64 {
 // session pool.
 func (s *SessionManager) NewSession(conn *mysql.Conn) {
 	s.mu.Lock()
-	s.sessions[conn.ConnectionID] = s.builder(conn, s.addr)
+	s.sessions[conn.ConnectionID], s.idxRegs[conn.ConnectionID], s.viewRegs[conn.ConnectionID] = s.builder(conn, s.addr)
 	s.mu.Unlock()
 }
 
@@ -85,9 +89,14 @@ func (s *SessionManager) NewContextWithQuery(
 ) *sql.Context {
 	s.mu.Lock()
 	sess, ok := s.sessions[conn.ConnectionID]
+	ir := s.idxRegs[conn.ConnectionID]
+	vr := s.viewRegs[conn.ConnectionID]
 	if !ok {
-		sess = s.builder(conn, s.addr)
+		sess, ir, vr = s.builder(conn, s.addr)
+
 		s.sessions[conn.ConnectionID] = sess
+		s.idxRegs[conn.ConnectionID] = ir
+		s.viewRegs[conn.ConnectionID] = vr
 	}
 	s.mu.Unlock()
 
@@ -99,6 +108,8 @@ func (s *SessionManager) NewContextWithQuery(
 		sql.WithQuery(query),
 		sql.WithMemoryManager(s.memory),
 		sql.WithRootSpan(s.tracer.StartSpan("query")),
+		sql.WithIndexRegistry(ir),
+		sql.WithViewRegistry(vr),
 	)
 
 	return context
@@ -110,4 +121,6 @@ func (s *SessionManager) CloseConn(conn *mysql.Conn) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.sessions, conn.ConnectionID)
+	delete(s.idxRegs, conn.ConnectionID)
+	delete(s.viewRegs, conn.ConnectionID)
 }

--- a/server/context.go
+++ b/server/context.go
@@ -10,16 +10,16 @@ import (
 )
 
 // SessionBuilder creates sessions given a MySQL connection and a server address.
-type SessionBuilder func(conn *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry)
+type SessionBuilder func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry, error)
 
 // DoneFunc is a function that must be executed when the session is used and
 // it can be disposed.
 type DoneFunc func()
 
 // DefaultSessionBuilder is a SessionBuilder that returns a base session.
-func DefaultSessionBuilder(c *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry) {
+func DefaultSessionBuilder(ctx context.Context, c *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry, error) {
 	client := c.RemoteAddr().String()
-	return sql.NewSession(addr, client, c.User, c.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry()
+	return sql.NewSession(addr, client, c.User, c.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry(), nil
 }
 
 // SessionManager is in charge of creating new sessions for the given
@@ -65,10 +65,14 @@ func (s *SessionManager) nextPid() uint64 {
 
 // NewSession creates a Session for the given connection and saves it to
 // session pool.
-func (s *SessionManager) NewSession(conn *mysql.Conn) {
+func (s *SessionManager) NewSession(ctx context.Context, conn *mysql.Conn) error {
+	var err error
+
 	s.mu.Lock()
-	s.sessions[conn.ConnectionID], s.idxRegs[conn.ConnectionID], s.viewRegs[conn.ConnectionID] = s.builder(conn, s.addr)
+	s.sessions[conn.ConnectionID], s.idxRegs[conn.ConnectionID], s.viewRegs[conn.ConnectionID], err = s.builder(ctx, conn, s.addr)
 	s.mu.Unlock()
+
+	return err
 }
 
 func (s *SessionManager) session(conn *mysql.Conn) sql.Session {
@@ -78,21 +82,24 @@ func (s *SessionManager) session(conn *mysql.Conn) sql.Session {
 }
 
 // NewContext creates a new context for the session at the given conn.
-func (s *SessionManager) NewContext(conn *mysql.Conn) *sql.Context {
+func (s *SessionManager) NewContext(conn *mysql.Conn) (*sql.Context, error) {
 	return s.NewContextWithQuery(conn, "")
 }
 
 // NewContextWithQuery creates a new context for the session at the given conn.
-func (s *SessionManager) NewContextWithQuery(
-	conn *mysql.Conn,
-	query string,
-) *sql.Context {
+func (s *SessionManager) NewContextWithQuery(conn *mysql.Conn, query string, ) (*sql.Context, error) {
+	ctx := context.Background()
 	s.mu.Lock()
 	sess, ok := s.sessions[conn.ConnectionID]
 	ir := s.idxRegs[conn.ConnectionID]
 	vr := s.viewRegs[conn.ConnectionID]
 	if !ok {
-		sess, ir, vr = s.builder(conn, s.addr)
+		var err error
+		sess, ir, vr, err = s.builder(ctx, conn, s.addr)
+
+		if err != nil {
+			return  nil, err
+		}
 
 		s.sessions[conn.ConnectionID] = sess
 		s.idxRegs[conn.ConnectionID] = ir
@@ -101,7 +108,7 @@ func (s *SessionManager) NewContextWithQuery(
 	s.mu.Unlock()
 
 	context := sql.NewContext(
-		context.Background(),
+		ctx,
 		sql.WithSession(sess),
 		sql.WithTracer(s.tracer),
 		sql.WithPid(s.nextPid()),
@@ -112,7 +119,7 @@ func (s *SessionManager) NewContextWithQuery(
 		sql.WithViewRegistry(vr),
 	)
 
-	return context
+	return context, nil
 }
 
 // CloseConn closes the connection in the session manager and all its

--- a/server/handler.go
+++ b/server/handler.go
@@ -128,7 +128,11 @@ func (h *Handler) ComQuery(
 	query string,
 	callback func(*sqltypes.Result) error,
 ) (err error) {
-	ctx := h.sm.NewContextWithQuery(c, query)
+	ctx, err := h.sm.NewContextWithQuery(c, query)
+
+	if err != nil {
+		return err
+	}
 
 	if !h.e.Async(ctx, query) {
 		newCtx, cancel := context.WithCancel(ctx)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -131,8 +131,8 @@ func TestHandlerKill(t *testing.T) {
 	handler := NewHandler(
 		e,
 		NewSessionManager(
-			func(conn *mysql.Conn, addr string) sql.Session {
-				return sql.NewSession(addr, "", "", conn.ConnectionID)
+			func(conn *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry) {
+				return sql.NewSession(addr, "", "", conn.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry()
 			},
 			opentracing.NoopTracer{},
 			sql.NewMemoryManager(nil),

--- a/server/handler_test_common.go
+++ b/server/handler_test_common.go
@@ -82,9 +82,9 @@ func brokenTestServer(t *testing.T, ready chan struct{}, port string) {
 
 // This session builder is used as dummy mysql Conn is not complete and
 // causes panic when accessing remote address.
-func testSessionBuilder(c *mysql.Conn, addr string) sql.Session {
+func testSessionBuilder(c *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry) {
 	const client = "127.0.0.1:34567"
-	return sql.NewSession(addr, client, c.User, c.ConnectionID)
+	return sql.NewSession(addr, client, c.User, c.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry()
 }
 
 type mockConn struct {

--- a/server/handler_test_common.go
+++ b/server/handler_test_common.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"reflect"
@@ -82,9 +83,9 @@ func brokenTestServer(t *testing.T, ready chan struct{}, port string) {
 
 // This session builder is used as dummy mysql Conn is not complete and
 // causes panic when accessing remote address.
-func testSessionBuilder(c *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry) {
+func testSessionBuilder(ctx context.Context, c *mysql.Conn, addr string) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry, error) {
 	const client = "127.0.0.1:34567"
-	return sql.NewSession(addr, client, c.User, c.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry()
+	return sql.NewSession(addr, client, c.User, c.ConnectionID), sql.NewIndexRegistry(), sql.NewViewRegistry(), nil
 }
 
 type mockConn struct {

--- a/sql/analyzer/assign_catalog.go
+++ b/sql/analyzer/assign_catalog.go
@@ -28,7 +28,7 @@ func assignCatalog(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 			return &nc, nil
 		case *plan.ShowIndexes:
 			nc := *node
-			nc.Registry = a.Catalog.IndexRegistry
+			nc.Registry = ctx.IndexRegistry
 			return &nc, nil
 		case *plan.ShowDatabases:
 			nc := *node

--- a/sql/analyzer/assign_indexes.go
+++ b/sql/analyzer/assign_indexes.go
@@ -152,7 +152,7 @@ func getIndexes(ctx *sql.Context, e sql.Expression, aliases map[string]sql.Expre
 		// the right branch is evaluable and the indexlookup supports set
 		// operations.
 		if !isEvaluable(c.Left()) && isEvaluable(c.Right()) {
-			idx := ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, c.Left())...)
+			idx := ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, c.Left())...)
 			if idx != nil {
 				var nidx sql.NegateIndex
 				if negate {
@@ -247,7 +247,7 @@ func getIndexes(ctx *sql.Context, e sql.Expression, aliases map[string]sql.Expre
 		}
 	case *expression.Between:
 		if !isEvaluable(e.Val) && isEvaluable(e.Upper) && isEvaluable(e.Lower) {
-			idx := ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Val)...)
+			idx := ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Val)...)
 			if idx != nil {
 				// release the index if it was not used
 				defer func() {
@@ -404,7 +404,7 @@ func getComparisonIndex(
 	}
 
 	if !isEvaluable(left) && isEvaluable(right) {
-		idx := ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, left)...)
+		idx := ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, left)...)
 		if idx != nil {
 			value, err := right.Eval(sql.NewEmptyContext(), nil)
 			if err != nil {
@@ -481,7 +481,7 @@ func getNegatedIndexes(ctx *sql.Context, a *Analyzer, not *expression.Not, alias
 			return nil, nil
 		}
 
-		idx := ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, left)...)
+		idx := ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, left)...)
 		if idx == nil {
 			return nil, nil
 		}
@@ -643,7 +643,7 @@ func getMultiColumnIndexForExpressions(
 	used map[sql.Expression]struct{},
 	aliases map[string]sql.Expression,
 ) (index sql.Index, lookup sql.IndexLookup, err error) {
-	index = ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, selected...)...)
+	index = ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, selected...)...)
 	if index != nil {
 		var first sql.Expression
 		for _, e := range exprs {

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -252,8 +252,8 @@ func getJoinEqualityIndex(
 	}
 
 	leftIdx, rightIdx =
-			ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Left())...),
-			ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Right())...)
+			ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Left())...),
+			ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, e.Right())...)
 
 	return leftIdx, rightIdx
 }
@@ -290,7 +290,7 @@ func getMultiColumnJoinIndex(ctx *sql.Context, exprs []sql.Expression, a *Analyz
 
 	exprsByTable := joinExprsByTable(exprs)
 	for table, cols := range exprsByTable {
-		idx := ctx.IndexByExpression(a.Catalog.CurrentDatabase(), unifyExpressions(aliases, extractExpressions(cols)...)...)
+		idx := ctx.IndexByExpression(ctx, a.Catalog.CurrentDatabase(), unifyExpressions(aliases, extractExpressions(cols)...)...)
 		if idx != nil {
 			result[table] = idx
 		}

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -59,7 +59,7 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	}
 
 	a.Log("transforming nodes with pushdown of filters, projections and indexes")
-	return transformPushdown(a, n, filters, indexes, fieldsByTable)
+	return transformPushdown(ctx, a, n, filters, indexes, fieldsByTable)
 }
 
 // fixFieldIndexesOnExpressions executes fixFieldIndexes on a list of exprs.
@@ -138,6 +138,7 @@ func findFilters(ctx *sql.Context, n sql.Node) filters {
 }
 
 func transformPushdown(
+	ctx *sql.Context,
 	a *Analyzer,
 	n sql.Node,
 	filters filters,
@@ -181,7 +182,7 @@ func transformPushdown(
 
 	release := func() {
 		for _, idx := range queryIndexes {
-			a.Catalog.ReleaseIndex(idx)
+			ctx.ReleaseIndex(idx)
 		}
 	}
 

--- a/sql/analyzer/resolve_subqueries_test.go
+++ b/sql/analyzer/resolve_subqueries_test.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/src-d/go-mysql-server/memory"
@@ -84,7 +85,8 @@ func TestResolveSubqueries(t *testing.T) {
 		),
 	)
 
-	result, err := resolveSubqueries(sql.NewEmptyContext(), a, node)
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(sql.NewIndexRegistry()), sql.WithViewRegistry(sql.NewViewRegistry()))
+	result, err := resolveSubqueries(ctx, a, node)
 	require.NoError(err)
 	require.Equal(expected, result)
 }

--- a/sql/analyzer/resolve_views.go
+++ b/sql/analyzer/resolve_views.go
@@ -28,7 +28,7 @@ func resolveViews(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 			db = a.Catalog.CurrentDatabase()
 		}
 
-		view, err := ctx.ViewRegistry.View(db, name)
+		view, err := ctx.View(db, name)
 		if err == nil {
 			a.Log("view resolved: %q", name)
 

--- a/sql/analyzer/resolve_views.go
+++ b/sql/analyzer/resolve_views.go
@@ -28,7 +28,7 @@ func resolveViews(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 			db = a.Catalog.CurrentDatabase()
 		}
 
-		view, err := a.Catalog.ViewRegistry.View(db, name)
+		view, err := ctx.ViewRegistry.View(db, name)
 		if err == nil {
 			a.Log("view resolved: %q", name)
 

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -42,8 +42,6 @@ type (
 func NewCatalog() *Catalog {
 	return &Catalog{
 		FunctionRegistry: NewFunctionRegistry(),
-		//IndexRegistry:    NewIndexRegistry(),
-		//ViewRegistry:     NewViewRegistry(),
 		MemoryManager:    NewMemoryManager(ProcessMemory),
 		ProcessList:      NewProcessList(),
 		locks:            make(sessionLocks),

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -23,8 +23,6 @@ var ErrIncompatibleAsOf = errors.NewKind("incompatible use of AS OF: %s")
 // Catalog holds databases, tables and functions.
 type Catalog struct {
 	FunctionRegistry
-	*IndexRegistry
-	*ViewRegistry
 	*ProcessList
 	*MemoryManager
 
@@ -44,8 +42,8 @@ type (
 func NewCatalog() *Catalog {
 	return &Catalog{
 		FunctionRegistry: NewFunctionRegistry(),
-		IndexRegistry:    NewIndexRegistry(),
-		ViewRegistry:     NewViewRegistry(),
+		//IndexRegistry:    NewIndexRegistry(),
+		//ViewRegistry:     NewViewRegistry(),
 		MemoryManager:    NewMemoryManager(ProcessMemory),
 		ProcessList:      NewProcessList(),
 		locks:            make(sessionLocks),
@@ -98,7 +96,7 @@ func (c *Catalog) Database(db string) (Database, error) {
 func (c *Catalog) Table(ctx *Context, db, table string) (Table, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.dbs.Table(ctx, db, table, c.IndexRegistry)
+	return c.dbs.Table(ctx, db, table)
 }
 
 // TableAsOf returns the table in the given database with the given name, as it existed at the time given. The database
@@ -137,7 +135,7 @@ func (d *Databases) Add(db Database) {
 }
 
 // Table returns the Table with the given name if it exists.
-func (d Databases) Table(ctx *Context, dbName string, tableName string, idxReg *IndexRegistry) (Table, error) {
+func (d Databases) Table(ctx *Context, dbName string, tableName string) (Table, error) {
 	db, err := d.Database(dbName)
 	if err != nil {
 		return nil, err
@@ -224,7 +222,7 @@ func (c *Catalog) UnlockTables(ctx *Context, id uint32) error {
 	var errors []string
 	for db, tables := range c.locks[id] {
 		for t := range tables {
-			table, err := c.dbs.Table(ctx, db, t, c.IndexRegistry)
+			table, err := c.dbs.Table(ctx, db, t)
 			if err == nil {
 				if lockable, ok := table.(Lockable); ok {
 					if e := lockable.Unlock(ctx, id); e != nil {

--- a/sql/catalog_test.go
+++ b/sql/catalog_test.go
@@ -106,7 +106,8 @@ func TestCatalogUnlockTables(t *testing.T) {
 	c.LockTable(1, "t1")
 	c.LockTable(1, "t2")
 
-	require.NoError(c.UnlockTables(nil, 1))
+	ctx := sql.NewEmptyContext()
+	require.NoError(c.UnlockTables(ctx, 1))
 
 	require.Equal(1, t1.unlocks)
 	require.Equal(1, t2.unlocks)

--- a/sql/index/pilosa/driver.go
+++ b/sql/index/pilosa/driver.go
@@ -157,7 +157,7 @@ func (d *Driver) Create(
 var errReadIndexes = errors.NewKind("error loading all indexes for table %s of database %s: %s")
 
 // LoadAll loads all indexes for given db and table
-func (d *Driver) LoadAll(db, table string) ([]sql.Index, error) {
+func (d *Driver) LoadAll(ctx *sql.Context, db, table string) ([]sql.Index, error) {
 	var (
 		indexes []sql.Index
 		errors  []string

--- a/sql/index/pilosa/driver_test.go
+++ b/sql/index/pilosa/driver_test.go
@@ -72,7 +72,7 @@ func TestLoadAll(t *testing.T) {
 	}
 	require.NoError(d.Save(sql.NewEmptyContext(), idx2, it2))
 
-	indexes, err := d.LoadAll("db", "table")
+	indexes, err := d.LoadAll(sql.NewContext(context.Background()), "db", "table")
 	require.NoError(err)
 
 	require.Equal(2, len(indexes))
@@ -97,7 +97,7 @@ func TestLoadAll(t *testing.T) {
 	}
 	require.NoError(d.Save(sql.NewEmptyContext(), idx3, it3))
 
-	_, err = d.LoadAll("db", "table2")
+	_, err = d.LoadAll(sql.NewContext(context.Background()), "db", "table2")
 	require.NoError(err)
 }
 
@@ -131,7 +131,7 @@ func TestLoadAllWithMultipleDrivers(t *testing.T) {
 	require.NoError(d2.Save(sql.NewEmptyContext(), idx2, it2))
 
 	d := NewDriver(tmpDir)
-	indexes, err := d.LoadAll("db", "table")
+	indexes, err := d.LoadAll(sql.NewContext(context.Background()), "db", "table")
 	require.NoError(err)
 
 	require.Equal(2, len(indexes))
@@ -157,7 +157,7 @@ func TestLoadAllWithMultipleDrivers(t *testing.T) {
 	}
 	require.NoError(d3.Save(sql.NewEmptyContext(), idx3, it3))
 
-	_, err = d.LoadAll("db", "table2")
+	_, err = d.LoadAll(sql.NewContext(context.Background()), "db", "table2")
 	require.NoError(err)
 }
 
@@ -186,7 +186,7 @@ func TestSaveAndLoad(t *testing.T) {
 	err = d.Save(ctx, sqlIdx, it)
 	require.NoError(err)
 
-	indexes, err := d.LoadAll(db, table)
+	indexes, err := d.LoadAll(sql.NewContext(context.Background()), db, table)
 	require.NoError(err)
 	require.Equal(1, len(indexes))
 
@@ -266,7 +266,7 @@ func TestSaveAndGetAll(t *testing.T) {
 	err = d.Save(sql.NewEmptyContext(), sqlIdx, it)
 	require.NoError(err)
 
-	indexes, err := d.LoadAll(db, table)
+	indexes, err := d.LoadAll(sql.NewContext(context.Background()), db, table)
 	require.NoError(err)
 	require.Equal(1, len(indexes))
 
@@ -299,7 +299,7 @@ func TestSaveAndGetAllWithMultipleDrivers(t *testing.T) {
 	require.NoError(err)
 
 	d2 := NewDriver(tmpDir)
-	indexes, err := d2.LoadAll(db, table)
+	indexes, err := d2.LoadAll(sql.NewContext(context.Background()), db, table)
 	require.NoError(err)
 	require.Equal(1, len(indexes))
 
@@ -395,7 +395,7 @@ func TestDeleteAndLoadAll(t *testing.T) {
 	err = d.Delete(sqlIdx, new(partitionIter))
 	require.NoError(err)
 
-	indexes, err := d.LoadAll(db, table)
+	indexes, err := d.LoadAll(sql.NewContext(context.Background()), db, table)
 	require.NoError(err)
 	require.Equal(0, len(indexes))
 }
@@ -441,7 +441,7 @@ func TestLoadAllDirectoryDoesNotExist(t *testing.T) {
 	defer cleanup(t)
 
 	driver := NewDriver(tmpDir)
-	indexes, err := driver.LoadAll("foo", "bar")
+	indexes, err := driver.LoadAll(sql.NewContext(context.Background()), "foo", "bar")
 	require.NoError(err)
 	require.Len(indexes, 0)
 }

--- a/sql/index_test.go
+++ b/sql/index_test.go
@@ -89,16 +89,17 @@ func TestIndexByExpression(t *testing.T) {
 	}
 	r.statuses[indexKey{"foo", ""}] = IndexReady
 
-	idx := r.IndexByExpression("bar", dummyExpr{1, "2"})
+	ctx := NewEmptyContext()
+	idx := r.IndexByExpression(ctx, "bar", dummyExpr{1, "2"})
 	require.Nil(idx)
 
-	idx = r.IndexByExpression("foo", dummyExpr{1, "2"})
+	idx = r.IndexByExpression(ctx, "foo", dummyExpr{1, "2"})
 	require.NotNil(idx)
 
-	idx = r.IndexByExpression("foo", dummyExpr{2, "3"})
+	idx = r.IndexByExpression(ctx, "foo", dummyExpr{2, "3"})
 	require.Nil(idx)
 
-	idx = r.IndexByExpression("foo", dummyExpr{3, "4"})
+	idx = r.IndexByExpression(ctx, "foo", dummyExpr{3, "4"})
 	require.Nil(idx)
 }
 
@@ -285,7 +286,7 @@ func TestLoadIndexes(t *testing.T) {
 		},
 	}
 
-	require.NoError(registry.LoadIndexes(dbs))
+	require.NoError(registry.LoadIndexes(ctx, dbs))
 	require.NoError(registry.registerIndexesForTable(ctx, "db1", "t1"))
 	require.NoError(registry.registerIndexesForTable(ctx, "db1", "t2"))
 	require.NoError(registry.registerIndexesForTable(ctx, "db2", "t3"))
@@ -326,7 +327,7 @@ func TestLoadOutdatedIndexes(t *testing.T) {
 		},
 	}
 
-	require.NoError(registry.LoadIndexes(dbs))
+	require.NoError(registry.LoadIndexes(ctx, dbs))
 	require.NoError(registry.registerIndexesForTable(ctx, "db1", "t1"))
 	require.NoError(registry.registerIndexesForTable(ctx, "db1", "t2"))
 
@@ -380,7 +381,7 @@ func (d loadDriver) ID() string { return d.id }
 func (loadDriver) Create(db, table, id string, expressions []Expression, config map[string]string) (Index, error) {
 	panic("create is a placeholder")
 }
-func (d loadDriver) LoadAll(db, table string) ([]Index, error) {
+func (d loadDriver) LoadAll(ctx *Context, db, table string) ([]Index, error) {
 	var result []Index
 	for _, i := range d.indexes {
 		if i.Table() == table && i.Database() == db {

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -110,9 +110,9 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 
 	var driver sql.IndexDriver
 	if c.Driver == "" {
-		driver = c.Catalog.DefaultIndexDriver()
+		driver = ctx.DefaultIndexDriver()
 	} else {
-		driver = c.Catalog.IndexDriver(c.Driver)
+		driver = ctx.IndexDriver(c.Driver)
 	}
 
 	if driver == nil {
@@ -160,7 +160,7 @@ func (c *CreateIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		iter:    iter,
 	}
 
-	created, ready, err := c.Catalog.AddIndex(index)
+	created, ready, err := ctx.AddIndex(index)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (c *CreateIndex) createIndex(
 		ctx.Error(0, "unable to save the index: %s", err)
 		logrus.WithField("err", err).Error("unable to save the index")
 
-		deleted, err := c.Catalog.DeleteIndex(index.Database(), index.ID(), true)
+		deleted, err := ctx.DeleteIndex(index.Database(), index.ID(), true)
 		if err != nil {
 			ctx.Error(0, "unable to delete index: %s", err)
 			logrus.WithField("err", err).Error("unable to delete the index")

--- a/sql/plan/create_index_test.go
+++ b/sql/plan/create_index_test.go
@@ -389,7 +389,7 @@ func (d *mockDriver) Create(db, table, id string, exprs []sql.Expression, config
 
 	return &mockIndex{db, table, id, exprs}, nil
 }
-func (*mockDriver) LoadAll(db, table string) ([]sql.Index, error) {
+func (*mockDriver) LoadAll(ctx *sql.Context, db, table string) ([]sql.Index, error) {
 	panic("not implemented")
 }
 

--- a/sql/plan/create_index_test.go
+++ b/sql/plan/create_index_test.go
@@ -24,9 +24,10 @@ func TestCreateIndexAsync(t *testing.T) {
 		{Name: "c", Source: "foo"},
 	})
 
+	idxReg := sql.NewIndexRegistry()
 	driver := new(mockDriver)
 	catalog := sql.NewCatalog()
-	catalog.RegisterIndexDriver(driver)
+	idxReg.RegisterIndexDriver(driver)
 	db := memory.NewDatabase("foo")
 	db.AddTable("foo", table)
 	catalog.AddDatabase(db)
@@ -43,7 +44,7 @@ func TestCreateIndexAsync(t *testing.T) {
 	ci.CurrentDatabase = "foo"
 
 	tracer := new(test.MemTracer)
-	ctx := sql.NewContext(context.Background(), sql.WithTracer(tracer))
+	ctx := sql.NewContext(context.Background(), sql.WithTracer(tracer), sql.WithIndexRegistry(idxReg), sql.WithViewRegistry(sql.NewViewRegistry()))
 	_, err := ci.RowIter(ctx)
 	require.NoError(err)
 
@@ -51,7 +52,7 @@ func TestCreateIndexAsync(t *testing.T) {
 
 	require.Len(driver.deleted, 0)
 	require.Equal([]string{"idx"}, driver.saved)
-	idx := catalog.IndexRegistry.Index("foo", "idx")
+	idx := idxReg.Index("foo", "idx")
 	require.NotNil(idx)
 	require.Equal(&mockIndex{"foo", "foo", "idx", []sql.Expression{
 		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true),
@@ -80,7 +81,8 @@ func TestCreateIndexNotIndexableExprs(t *testing.T) {
 
 	driver := new(mockDriver)
 	catalog := sql.NewCatalog()
-	catalog.RegisterIndexDriver(driver)
+	idxReg := sql.NewIndexRegistry()
+	idxReg.RegisterIndexDriver(driver)
 	db := memory.NewDatabase("foo")
 	db.AddTable("foo", table)
 	catalog.AddDatabase(db)
@@ -97,7 +99,8 @@ func TestCreateIndexNotIndexableExprs(t *testing.T) {
 	ci.Catalog = catalog
 	ci.CurrentDatabase = "foo"
 
-	_, err := ci.RowIter(sql.NewEmptyContext())
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(idxReg), sql.WithViewRegistry(sql.NewViewRegistry()))
+	_, err := ci.RowIter(ctx)
 	require.Error(err)
 	require.True(ErrExprTypeNotIndexable.Is(err))
 
@@ -113,7 +116,7 @@ func TestCreateIndexNotIndexableExprs(t *testing.T) {
 	ci.Catalog = catalog
 	ci.CurrentDatabase = "foo"
 
-	_, err = ci.RowIter(sql.NewEmptyContext())
+	_, err = ci.RowIter(ctx)
 	require.Error(err)
 	require.True(ErrExprTypeNotIndexable.Is(err))
 }
@@ -129,7 +132,8 @@ func TestCreateIndexSync(t *testing.T) {
 
 	driver := new(mockDriver)
 	catalog := sql.NewCatalog()
-	catalog.RegisterIndexDriver(driver)
+	idxReg := sql.NewIndexRegistry()
+	idxReg.RegisterIndexDriver(driver)
 	db := memory.NewDatabase("foo")
 	db.AddTable("foo", table)
 	catalog.AddDatabase(db)
@@ -147,13 +151,13 @@ func TestCreateIndexSync(t *testing.T) {
 	ci.CurrentDatabase = "foo"
 
 	tracer := new(test.MemTracer)
-	ctx := sql.NewContext(context.Background(), sql.WithTracer(tracer))
+	ctx := sql.NewContext(context.Background(), sql.WithTracer(tracer), sql.WithIndexRegistry(idxReg))
 	_, err := ci.RowIter(ctx)
 	require.NoError(err)
 
 	require.Len(driver.deleted, 0)
 	require.Equal([]string{"idx"}, driver.saved)
-	idx := catalog.IndexRegistry.Index("foo", "idx")
+	idx := idxReg.Index("foo", "idx")
 	require.NotNil(idx)
 	require.Equal(&mockIndex{"foo", "foo", "idx", []sql.Expression{
 		expression.NewGetFieldWithTable(0, sql.Int64, "foo", "c", true),
@@ -185,7 +189,8 @@ func TestCreateIndexChecksum(t *testing.T) {
 
 	driver := new(mockDriver)
 	catalog := sql.NewCatalog()
-	catalog.RegisterIndexDriver(driver)
+	idxReg := sql.NewIndexRegistry()
+	idxReg.RegisterIndexDriver(driver)
 	db := memory.NewDatabase("foo")
 	db.AddTable("foo", table)
 	catalog.AddDatabase(db)
@@ -202,7 +207,8 @@ func TestCreateIndexChecksum(t *testing.T) {
 	ci.Catalog = catalog
 	ci.CurrentDatabase = "foo"
 
-	_, err := ci.RowIter(sql.NewEmptyContext())
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(idxReg))
+	_, err := ci.RowIter(ctx)
 	require.NoError(err)
 
 	require.Equal([]string{"idx"}, driver.saved)
@@ -230,7 +236,8 @@ func TestCreateIndexChecksumWithUnderlying(t *testing.T) {
 
 	driver := new(mockDriver)
 	catalog := sql.NewCatalog()
-	catalog.RegisterIndexDriver(driver)
+	idxReg := sql.NewIndexRegistry()
+	idxReg.RegisterIndexDriver(driver)
 
 	exprs := []sql.Expression{
 		expression.NewGetFieldWithTable(2, sql.Int64, "foo", "c", true),
@@ -244,7 +251,8 @@ func TestCreateIndexChecksumWithUnderlying(t *testing.T) {
 	ci.Catalog = catalog
 	ci.CurrentDatabase = "foo"
 
-	_, err := ci.RowIter(sql.NewEmptyContext())
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(idxReg))
+	_, err := ci.RowIter(ctx)
 	require.NoError(err)
 
 	require.Equal([]string{"idx"}, driver.saved)
@@ -276,7 +284,8 @@ func TestCreateIndexWithIter(t *testing.T) {
 
 	driver := new(mockDriver)
 	catalog := sql.NewCatalog()
-	catalog.RegisterIndexDriver(driver)
+	idxReg := sql.NewIndexRegistry()
+	idxReg.RegisterIndexDriver(driver)
 	db := memory.NewDatabase("foo")
 	db.AddTable("foo", foo)
 	catalog.AddDatabase(db)
@@ -288,11 +297,12 @@ func TestCreateIndexWithIter(t *testing.T) {
 	columns, exprs, err := getColumnsAndPrepareExpressions(ci.Exprs)
 	require.NoError(err)
 
-	iter, err := foo.IndexKeyValues(sql.NewEmptyContext(), columns)
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(idxReg))
+	iter, err := foo.IndexKeyValues(ctx, columns)
 	require.NoError(err)
 
 	iter = &evalPartitionKeyValueIter{
-		ctx:     sql.NewEmptyContext(),
+		ctx:     ctx,
 		columns: columns,
 		exprs:   exprs,
 		iter:    iter,

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -67,7 +67,7 @@ func (cv *CreateView) Resolved() bool {
 // empty.
 func (cv *CreateView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	view := cv.View()
-	registry := cv.Catalog.ViewRegistry
+	registry := ctx.ViewRegistry
 
 	if cv.IsReplace {
 		err := registry.Delete(cv.database.Name(), view.Name())

--- a/sql/plan/drop_index.go
+++ b/sql/plan/drop_index.go
@@ -69,22 +69,22 @@ func (d *DropIndex) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		return nil, sql.ErrTableNotFound.New(n.Name() + similar)
 	}
 
-	index := d.Catalog.Index(db.Name(), d.Name)
+	index := ctx.Index(db.Name(), d.Name)
 	if index == nil {
 		return nil, ErrIndexNotFound.New(d.Name, n.Name(), db.Name())
 	}
-	d.Catalog.ReleaseIndex(index)
+	ctx.ReleaseIndex(index)
 
-	if !d.Catalog.CanRemoveIndex(index) {
+	if !ctx.CanRemoveIndex(index) {
 		return nil, ErrIndexNotAvailable.New(d.Name)
 	}
 
-	done, err := d.Catalog.DeleteIndex(db.Name(), d.Name, true)
+	done, err := ctx.DeleteIndex(db.Name(), d.Name, true)
 	if err != nil {
 		return nil, err
 	}
 
-	driver := d.Catalog.IndexDriver(index.Driver())
+	driver := ctx.IndexDriver(index.Driver())
 	if driver == nil {
 		return nil, ErrInvalidIndexDriver.New(index.Driver())
 	}

--- a/sql/plan/drop_view.go
+++ b/sql/plan/drop_view.go
@@ -128,7 +128,7 @@ func (dvs *DropView) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		viewList[i] = sql.NewViewKey(drop.database.Name(), drop.viewName)
 	}
 
-	return sql.RowsToRowIter(), dvs.Catalog.ViewRegistry.DeleteList(viewList, !dvs.ifExists)
+	return sql.RowsToRowIter(), ctx.ViewRegistry.DeleteList(viewList, !dvs.ifExists)
 }
 
 // Schema implements the Node interface. It always returns nil.

--- a/sql/plan/drop_view_test.go
+++ b/sql/plan/drop_view_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"context"
 	"testing"
 
 	"github.com/src-d/go-mysql-server/memory"
@@ -37,7 +38,7 @@ func mockData(require *require.Assertions) (sql.Database, *sql.Catalog, *sql.Con
 	createView := NewCreateView(db, subqueryAlias.Name(), nil, subqueryAlias, "select i from dual", false)
 	createView.Catalog = catalog
 
-	ctx := sql.NewEmptyContext()
+	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(sql.NewIndexRegistry()), sql.WithViewRegistry(sql.NewViewRegistry()))
 
 	_, err := createView.RowIter(ctx)
 	require.NoError(err)
@@ -60,7 +61,7 @@ func TestDropExistingView(t *testing.T) {
 		_, err := dropView.RowIter(ctx)
 		require.NoError(err)
 
-		require.False(catalog.ViewRegistry.Exists(db.Name(), view.Name()))
+		require.False(ctx.Exists(db.Name(), view.Name()))
 	}
 
 	test(false)
@@ -81,7 +82,7 @@ func TestDropNonExistingView(t *testing.T) {
 
 		_, err := dropView.RowIter(ctx)
 
-		require.True(catalog.ViewRegistry.Exists(db.Name(), view.Name()))
+		require.True(ctx.Exists(db.Name(), view.Name()))
 
 		return err
 	}

--- a/sql/session.go
+++ b/sql/session.go
@@ -207,6 +207,9 @@ func NewBaseSession() Session {
 	return &BaseSession{config: DefaultSessionConfig()}
 }
 
+var defIdxReg = NewIndexRegistry()
+var defViewReg = NewViewRegistry()
+
 // Context of the query execution.
 type Context struct {
 	context.Context
@@ -289,6 +292,14 @@ func NewContext(
 	c := &Context{ctx, NewBaseSession(), nil, nil, nil, 0, "", opentracing.NoopTracer{}, nil}
 	for _, opt := range opts {
 		opt(c)
+	}
+
+	if c.IndexRegistry == nil {
+		c.IndexRegistry = defIdxReg
+	}
+
+	if c.ViewRegistry == nil {
+		c.ViewRegistry = defViewReg
 	}
 
 	if c.Memory == nil {


### PR DESCRIPTION
Want your thoughts on moving the IndexRegistry and the ViewRegistry out of the Catalog object and making them accessible as part of the context.  It's now up to the SessionBuilder implementation to provide the IndexRegistry and ViewRegistry for a session.  In dolt we would register indexes and views at that point, and would be altered when the connection changes what head is pointed at.