### PR TITLE
Zachmu/user privileges

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -630,6 +630,15 @@ var queries = []queryTest{
 			{int64(3), int64(3), "first"},
 		},
 	},
+	// TODO: this should work, but generates a table name conflict right now
+	// {
+	// 	"SELECT i, i2, s2 FROM mytable as OTHERTABLE INNER JOIN othertable as MYTABLE ON i = i2 ORDER BY i",
+	// 	[]sql.Row{
+	// 		{int64(1), int64(1), "third"},
+	// 		{int64(2), int64(2), "second"},
+	// 		{int64(3), int64(3), "first"},
+	// 	},
+	// },
 	{
 		"SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
 		[]sql.Row{
@@ -4458,6 +4467,22 @@ var errorQueries = []queryError {
 	{
 		query:       "select foo.i from mytable as a",
 		expectedErr: sql.ErrTableNotFound,
+	},
+	{
+		query:       "select foo.i from mytable",
+		expectedErr: sql.ErrTableNotFound,
+	},
+	{
+		query:       "select foo.* from mytable",
+		expectedErr: sql.ErrTableNotFound,
+	},
+	{
+		query:       "select foo.* from mytable as a",
+		expectedErr: sql.ErrTableNotFound,
+	},
+	{
+		query:       "select x from mytable",
+		expectedErr: analyzer.ErrColumnNotFound,
 	},
 	{
 		query:       "select myTable.i from mytable as mt", // alias overwrites the original table name

--- a/engine_test.go
+++ b/engine_test.go
@@ -74,6 +74,13 @@ var queries = []queryTest{
 			{"third row", int64(3)}},
 	},
 	{
+		"SELECT S,I FROM MyTable ORDER BY 2",
+		[]sql.Row{
+			{"first row", int64(1)},
+			{"second row", int64(2)},
+			{"third row", int64(3)}},
+	},
+	{
 		"SELECT mt.s,mt.i FROM MyTable MT ORDER BY 2;",
 		[]sql.Row{
 			{"first row", int64(1)},
@@ -81,28 +88,35 @@ var queries = []queryTest{
 			{"third row", int64(3)}},
 	},
 	{
-		"SELECT MyTABLE.s,myTable.i FROM MyTable MT ORDER BY 2;",
+		"SELECT mT.S,Mt.I FROM MyTable MT ORDER BY 2;",
 		[]sql.Row{
 			{"first row", int64(1)},
 			{"second row", int64(2)},
 			{"third row", int64(3)}},
 	},
 	{
-		"SELECT mt.* FROM MyTable MT ORDER BY 2;",
+		"SELECT mt.* FROM MyTable MT ORDER BY mT.I;",
+		[]sql.Row{
+			{int64(1), "first row"},
+			{int64(2), "second row"},
+			{int64(3), "third row"}},
+	},
+	{
+		"SELECT MyTABLE.s,myTable.i FROM MyTable ORDER BY 2;",
 		[]sql.Row{
 			{"first row", int64(1)},
 			{"second row", int64(2)},
 			{"third row", int64(3)}},
 	},
 	{
-		"SELECT myTable.* FROM MYTABLE mt ORDER BY myTable.i;",
+		"SELECT myTable.* FROM MYTABLE ORDER BY myTable.i;",
 		[]sql.Row{
-			{"first row", int64(1)},
-			{"second row", int64(2)},
-			{"third row", int64(3)}},
+			{int64(1), "first row"},
+			{int64(2), "second row"},
+			{int64(3), "third row"}},
 	},
 	{
-		"SELECT MyTABLE.S,myTable.I FROM MyTable MT ORDER BY mytable.i;",
+		"SELECT MyTABLE.S,myTable.I FROM MyTable ORDER BY mytable.i;",
 		[]sql.Row{
 			{"first row", int64(1)},
 			{"second row", int64(2)},

--- a/engine_test.go
+++ b/engine_test.go
@@ -2630,7 +2630,7 @@ var infoSchemaQueries = []queryTest {
 }
 
 // Set to a query to run only tests for that query
-var debugQuery = ""
+var debugQuery = ""//"SELECT mt.* FROM MyTable MT ORDER BY mT.I;"
 
 func TestQueries(t *testing.T) {
 	type indexDriverInitalizer func(map[string]*memory.Table) sql.IndexDriver
@@ -4526,6 +4526,14 @@ var errorQueries = []queryError {
 		query:       "select foo.i from mytable as a",
 		expectedErr: sql.ErrTableNotFound,
 	},
+	{
+		query:       "select myTable.i from mytable as mt", // alias overwrites the original table name
+		expectedErr: sql.ErrTableNotFound,
+	},
+	{
+		query:       "select myTable.* from mytable as mt", // alias overwrites the original table name
+		expectedErr: sql.ErrTableNotFound,
+	},
 }
 
 func TestQueryErrors(t *testing.T) {
@@ -5653,6 +5661,9 @@ func newEngineWithParallelism(t *testing.T, parallelism int, tables map[string]*
 	} else {
 		a = analyzer.NewDefault(catalog)
 	}
+
+	// a.Debug = true
+	// a.Verbose = true
 
 	idxReg := sql.NewIndexRegistry()
 	if driver != nil {

--- a/engine_test.go
+++ b/engine_test.go
@@ -4479,7 +4479,14 @@ var errorQueries = []queryError {
 		query:       "SELECT t.i, myview1.s FROM myview AS t ORDER BY i", // alias overwrites the original view name
 		expectedErr: sql.ErrTableNotFound,
 	},
-
+	{
+		query:       "SELECT * FROM mytable AS t, othertable as t", // duplicate alias
+		expectedErr: sql.ErrDuplicateAliasOrTable,
+	},
+	{
+		query:       "SELECT * FROM mytable AS OTHERTABLE, othertable", // alias / table conflict
+		expectedErr: sql.ErrDuplicateAliasOrTable,
+	},
 }
 
 func TestQueryErrors(t *testing.T) {

--- a/engine_test.go
+++ b/engine_test.go
@@ -135,7 +135,7 @@ var queries = []queryTest{
 		[]sql.Row{{"1.1", "aaa", "create"}},
 	},
 	{
-		"SELECT reservedWordsTable.AND, reservedWordsTABLE.Or, Rw.SEleCT FROM reservedWordsTable rw;",
+		"SELECT reservedWordsTable.AND, reservedWordsTABLE.Or, reservedwordstable.SEleCT FROM reservedWordsTable;",
 		[]sql.Row{{"1.1", "aaa", "create"}},
 	},
 	{
@@ -2630,7 +2630,7 @@ var infoSchemaQueries = []queryTest {
 }
 
 // Set to a query to run only tests for that query
-var debugQuery = ""//"SELECT mt.* FROM MyTable MT ORDER BY mT.I;"
+var debugQuery = ""//"SELECT myTable.* FROM MYTABLE ORDER BY myTable.i;"
 
 func TestQueries(t *testing.T) {
 	type indexDriverInitalizer func(map[string]*memory.Table) sql.IndexDriver

--- a/engine_test.go
+++ b/engine_test.go
@@ -39,6 +39,10 @@ var queries = []queryTest{
 		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
+		"SELECT i FROM mytable AS mt;",
+		[]sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
+	},
+	{
 		"SELECT s,i FROM mytable;",
 		[]sql.Row{
 			{"first row", int64(1)},

--- a/engine_test.go
+++ b/engine_test.go
@@ -2047,7 +2047,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT one_pk.c5,pk1,pk2 FROM one_pk opk, two_pk tpk WHERE pk=pk1 ORDER BY 1,2,3",
+		"SELECT opk.c5,pk1,pk2 FROM one_pk opk, two_pk tpk WHERE pk=pk1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -2065,7 +2065,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT one_pk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=pk1 ORDER BY 1,2,3",
+		"SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=pk1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -2074,7 +2074,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT one_pk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 ORDER BY 1,2,3",
+		"SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -2083,7 +2083,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT one_pk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON one_pk.pk=two_pk.pk1 ORDER BY 1,2,3",
+		"SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{0, 0, 1},
@@ -2112,14 +2112,14 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON one_pk.pk=two_pk.pk1 AND opk.pk=tpk.pk2 ORDER BY 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 AND opk.pk=tpk.pk2 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{1, 1, 1},
 		},
 	},
 	{
-		"SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=two_pk.pk1 AND pk=tpk.pk2 ORDER BY 1,2,3",
+		"SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=tpk.pk1 AND pk=tpk.pk2 ORDER BY 1,2,3",
 		[]sql.Row{
 			{0, 0, 0},
 			{1, 1, 1},
@@ -4534,6 +4534,15 @@ var errorQueries = []queryError {
 		query:       "select myTable.* from mytable as mt", // alias overwrites the original table name
 		expectedErr: sql.ErrTableNotFound,
 	},
+	{
+		query:       "SELECT one_pk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON one_pk.pk=two_pk.pk1 ORDER BY 1,2,3", // alias overwrites the original table name
+		expectedErr: sql.ErrTableNotFound,
+	},
+	{
+		query:       "SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON one_pk.pk=two_pk.pk1 AND opk.pk=tpk.pk2 ORDER BY 1,2,3", // alias overwrites the original table name
+		expectedErr: sql.ErrTableNotFound,
+	},
+
 }
 
 func TestQueryErrors(t *testing.T) {

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -41,10 +41,13 @@ func getIndexesByTable(ctx *sql.Context, a *Analyzer, node sql.Node) (indexLooku
 		}
 	}()
 
-	exprAliases := getExpressionAliases(node)
-	tableAliases := getTableAliases(node)
-
 	var err error
+	exprAliases := getExpressionAliases(node)
+	tableAliases, err := getTableAliases(node)
+	if err != nil {
+		return nil, err
+	}
+
 	plan.Inspect(node, func(node sql.Node) bool {
 		filter, ok := node.(*plan.Filter)
 		if !ok {

--- a/sql/analyzer/optimize_joins.go
+++ b/sql/analyzer/optimize_joins.go
@@ -39,7 +39,10 @@ func optimizeJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) 
 	}
 
 	exprAliases := getExpressionAliases(n)
-	tableAliases := getTableAliases(n)
+	tableAliases, err := getTableAliases(n)
+	if err != nil {
+		return nil, err
+	}
 
 	indexes, err := findJoinIndexes(ctx, n, exprAliases, tableAliases, a)
 	if err != nil {

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -53,7 +53,10 @@ func pushdown(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	}
 
 	exprAliases := getExpressionAliases(n)
-	tableAliases := getTableAliases(n)
+	tableAliases, err := getTableAliases(n)
+	if err != nil {
+		return nil, err
+	}
 
 	a.Log("transforming nodes with pushdown of filters, projections and indexes")
 	return transformPushdown(ctx, a, n, filters, indexes, fieldsByTable, exprAliases, tableAliases)

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -155,7 +155,7 @@ func qualifyExpression(
 
 		// If this column is already qualified, make sure the table name is known
 		if col.Table() != "" {
-			if _, ok := tables[col.Table()]; !ok {
+			if _, ok := tables[strings.ToLower(col.Table())]; !ok {
 				return nil, sql.ErrTableNotFound.New(col.Table())
 			}
 			return col, nil

--- a/sql/analyzer/resolve_natural_joins.go
+++ b/sql/analyzer/resolve_natural_joins.go
@@ -13,7 +13,10 @@ func resolveNaturalJoins(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, e
 	defer span.Finish()
 
 	var replacements = make(map[tableCol]tableCol)
-	var tableAliases = getTableAliases(n)
+	tableAliases, err := getTableAliases(n)
+	if err != nil {
+		return nil, err
+	}
 
 	return plan.TransformUp(n, func(node sql.Node) (sql.Node, error) {
 		switch n := node.(type) {

--- a/sql/analyzer/resolve_stars.go
+++ b/sql/analyzer/resolve_stars.go
@@ -4,6 +4,7 @@ import (
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
 	"github.com/liquidata-inc/go-mysql-server/sql/plan"
+	"strings"
 )
 
 func resolveStar(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
@@ -53,7 +54,8 @@ func expandStars(a *Analyzer, exprs []sql.Expression, schema sql.Schema, tableAl
 		if s, ok := e.(*expression.Star); ok {
 			var exprs []sql.Expression
 			for i, col := range schema {
-				if s.Table == "" || s.Table == col.Source || (tableAliases[col.Source] != nil && tableAliases[col.Source].Name() == s.Table) {
+				lowerSource := strings.ToLower(col.Source)
+				if s.Table == "" || s.Table == lowerSource || (tableAliases[lowerSource] != nil && tableAliases[lowerSource].Name() == s.Table) {
 					exprs = append(exprs, expression.NewGetFieldWithTable(
 						i, col.Type, col.Source, col.Name, col.Nullable,
 					))

--- a/sql/analyzer/resolve_stars.go
+++ b/sql/analyzer/resolve_stars.go
@@ -11,7 +11,10 @@ func resolveStar(ctx *sql.Context, a *Analyzer, n sql.Node) (sql.Node, error) {
 	span, _ := ctx.Span("resolve_star")
 	defer span.Finish()
 
-	tableAliases := getTableAliases(n)
+	tableAliases, err := getTableAliases(n)
+	if err != nil {
+		return nil, err
+	}
 
 	a.Log("resolving star, node of type: %T", n)
 	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {

--- a/sql/analyzer/resolve_stars.go
+++ b/sql/analyzer/resolve_stars.go
@@ -55,7 +55,9 @@ func expandStars(a *Analyzer, exprs []sql.Expression, schema sql.Schema, tableAl
 			var exprs []sql.Expression
 			for i, col := range schema {
 				lowerSource := strings.ToLower(col.Source)
-				if s.Table == "" || s.Table == lowerSource || (tableAliases[lowerSource] != nil && tableAliases[lowerSource].Name() == s.Table) {
+				lowerTable := strings.ToLower(s.Table)
+				if s.Table == "" || lowerTable == lowerSource ||
+					(tableAliases[lowerSource] != nil && strings.ToLower(tableAliases[lowerSource].Name()) == lowerTable) {
 					exprs = append(exprs, expression.NewGetFieldWithTable(
 						i, col.Type, col.Source, col.Name, col.Nullable,
 					))

--- a/sql/core.go
+++ b/sql/core.go
@@ -36,6 +36,9 @@ var (
 
 	// ErrDeleteRowNotFound
 	ErrDeleteRowNotFound = errors.NewKind("row was not found when attempting to delete").New()
+
+  // ErrDuplicateAlias should be returned when a query contains a duplicate alias / table name.
+  ErrDuplicateAliasOrTable = errors.NewKind("Not unique table/alias: %s")
 )
 
 // Nameable is something that has a name.

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -1,4 +1,4 @@
- package function
+package function
 
 import (
 	"encoding/json"

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -1,4 +1,4 @@
-package function
+ package function
 
 import (
 	"encoding/json"

--- a/sql/information_schema.go
+++ b/sql/information_schema.go
@@ -38,6 +38,8 @@ const (
 	RoutinesTableName = "routines"
 	// ViewsTableName is the name of the views table.
 	ViewsTableName = "views"
+	// UserPrivilegesTableName is the name of the user_privileges table
+	UserPrivilegesTableName = "user_privileges"
 )
 
 const (
@@ -348,6 +350,13 @@ var viewsSchema = Schema{
 	{Name: "collation_connection", Type: LongText, Default: nil, Nullable: false, Source: ViewsTableName},
 }
 
+var userPrivilegesSchema = Schema{
+	{Name: "grantee", Type: LongText, Default: nil, Nullable: false, Source: UserPrivilegesTableName},
+	{Name: "table_catalog", Type: LongText, Default: nil, Nullable: false, Source: UserPrivilegesTableName},
+	{Name: "privilege_type", Type: LongText, Default: nil, Nullable: false, Source: UserPrivilegesTableName},
+	{Name: "is_grantable", Type: LongText, Default: nil, Nullable: false, Source: UserPrivilegesTableName},
+}
+
 func tablesRowIter(ctx *Context, cat *Catalog) RowIter {
 	var rows []Row
 	for _, db := range cat.AllDatabases() {
@@ -596,6 +605,12 @@ func NewInformationSchemaDatabase(cat *Catalog) Database {
 				schema:  viewsSchema,
 				catalog: cat,
 				rowIter: viewRowIter,
+			},
+			UserPrivilegesTableName: &informationSchemaTable{
+				name:    UserPrivilegesTableName,
+				schema:  userPrivilegesSchema,
+				catalog: cat,
+				rowIter: emptyRowIter,
 			},
 		},
 	}


### PR DESCRIPTION
Adds an empty user_privileges table to the information_schema database. This is necessary for the latest version of datagrip.

Stacked on top of #102.