### PR TITLE
Zachmu/table naming regression

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -2346,6 +2346,42 @@ var queries = []queryTest{
 		},
 	},
 	{
+		"SELECT a.pk,b.pk FROM one_pk a JOIN one_pk b ON a.pk = b.pk",
+		[]sql.Row{
+			{0, 0},
+			{1, 1},
+			{2, 2},
+			{3, 3},
+		},
+	},
+	{
+		"SELECT a.pk,b.pk FROM one_pk a, one_pk b WHERE a.pk = b.pk",
+		[]sql.Row{
+			{0, 0},
+			{1, 1},
+			{2, 2},
+			{3, 3},
+		},
+	},
+	{
+		"SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk",
+		[]sql.Row{
+			{0, 0},
+			{1, 1},
+			{2, 2},
+			{3, 3},
+		},
+	},
+	{
+		"SELECT one_pk.pk,b.pk FROM one_pk, one_pk b WHERE one_pk.pk = b.pk",
+		[]sql.Row{
+			{0, 0},
+			{1, 1},
+			{2, 2},
+			{3, 3},
+		},
+	},
+	{
 		"SELECT 2.0 + CAST(5 AS DECIMAL)",
 		[]sql.Row{{float64(7)}},
 	},

--- a/engine_test.go
+++ b/engine_test.go
@@ -2663,7 +2663,7 @@ var infoSchemaQueries = []queryTest {
 }
 
 // Set to a query to run only tests for that query
-var debugQuery = ""//"SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk order by one_pk.pk"
+var debugQuery = ""
 
 func TestQueries(t *testing.T) {
 	type indexDriverInitalizer func(map[string]*memory.Table) sql.IndexDriver

--- a/engine_test.go
+++ b/engine_test.go
@@ -2346,7 +2346,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT a.pk,b.pk FROM one_pk a JOIN one_pk b ON a.pk = b.pk",
+		"SELECT a.pk,b.pk FROM one_pk a JOIN one_pk b ON a.pk = b.pk order by a.pk",
 		[]sql.Row{
 			{0, 0},
 			{1, 1},
@@ -2355,7 +2355,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT a.pk,b.pk FROM one_pk a, one_pk b WHERE a.pk = b.pk",
+		"SELECT a.pk,b.pk FROM one_pk a, one_pk b WHERE a.pk = b.pk order by a.pk",
 		[]sql.Row{
 			{0, 0},
 			{1, 1},
@@ -2364,7 +2364,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk",
+		"SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk order by one_pk.pk",
 		[]sql.Row{
 			{0, 0},
 			{1, 1},
@@ -2373,7 +2373,7 @@ var queries = []queryTest{
 		},
 	},
 	{
-		"SELECT one_pk.pk,b.pk FROM one_pk, one_pk b WHERE one_pk.pk = b.pk",
+		"SELECT one_pk.pk,b.pk FROM one_pk, one_pk b WHERE one_pk.pk = b.pk order by one_pk.pk",
 		[]sql.Row{
 			{0, 0},
 			{1, 1},
@@ -2663,7 +2663,7 @@ var infoSchemaQueries = []queryTest {
 }
 
 // Set to a query to run only tests for that query
-var debugQuery = ""
+var debugQuery = ""//"SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk order by one_pk.pk"
 
 func TestQueries(t *testing.T) {
 	type indexDriverInitalizer func(map[string]*memory.Table) sql.IndexDriver

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -365,22 +365,9 @@ func findChildIndexedColumns(n sql.Node) map[tableCol]indexedCol {
 	var idx int
 	var columns = make(map[tableCol]indexedCol)
 
-	// Err should be impossible here: aliases should already have been verified
-	aliases, err := getTableAliases(n)
-	if err != nil {
-		panic(err)
-	}
-
 	for _, child := range n.Children() {
 		childSch := child.Schema()
 		for _, col := range childSch {
-			// Columns of tables with an alias can be named by their aliased or unaliased name. Add an entry for both.
-			if aliasedTable, ok := aliases[strings.ToLower(col.Source)]; ok {
-				columns[tableCol{
-					table: strings.ToLower(aliasedTable.Name()),
-					col:   strings.ToLower(col.Name),
-				}] = indexedCol{col, idx}
-			}
 			columns[tableCol{
 				table: strings.ToLower(col.Source),
 				col:   strings.ToLower(col.Name),

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -289,8 +289,6 @@ func getTableNamesInNode(node sql.Node) map[string]string {
 				name := strings.ToLower(t.(sql.Nameable).Name())
 				alias := strings.ToLower(n.Name())
 				tables[alias] = name
-				// If a table has been aliased, you must refer to the table with the alias, not the original name. So delete it.
-				delete(tables, name)
 			}
 			return false
 		}


### PR DESCRIPTION
Fixed regression caused by update to alias handling. Removed a couple places that allowed aliased tables to be referred to by their unaliased names, which is an error.