### PR TITLE
Zachmu/index regression

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -33,6 +33,7 @@ var indexBehaviors = []*indexBehaviorTestParams{
 	{"none", nil, false},
 	{"unmergableIndexes", unmergableIndexDriver, false},
 	{"mergableIndexes", mergableIndexDriver, false},
+	// TODO: why isn't this test failing on native (primary key) indexes?
 	{"nativeIndexes", nil, true},
 	{"nativeAndMergable", mergableIndexDriver, true},
 }

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -33,7 +33,6 @@ var indexBehaviors = []*indexBehaviorTestParams{
 	{"none", nil, false},
 	{"unmergableIndexes", unmergableIndexDriver, false},
 	{"mergableIndexes", mergableIndexDriver, false},
-	// TODO: why isn't this test failing on native (primary key) indexes?
 	{"nativeIndexes", nil, true},
 	{"nativeAndMergable", mergableIndexDriver, true},
 }

--- a/enginetest/memoryharness_test.go
+++ b/enginetest/memoryharness_test.go
@@ -201,11 +201,13 @@ func mergableIndexDriver(dbs []sql.Database) sql.IndexDriver {
 func newUnmergableIndex(dbs []sql.Database, tableName string, exprs ...sql.Expression) *memory.UnmergeableIndex {
 	db, table := findTable(dbs, tableName)
 	return &memory.UnmergeableIndex{
-		DB:         db.Name(),
-		DriverName: memory.IndexDriverId,
-		TableName:  tableName,
-		Tbl:        table.(*memory.Table),
-		Exprs:      exprs,
+		memory.MergeableIndex{
+			DB:         db.Name(),
+			DriverName: memory.IndexDriverId,
+			TableName:  tableName,
+			Tbl:        table.(*memory.Table),
+			Exprs:      exprs,
+		},
 	}
 }
 

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -194,11 +194,23 @@ var QueryTests = []QueryTest{
 		[]sql.Row{{int64(2)}},
 	},
 	{
+		"SELECT i FROM mytable WHERE 2 = i;",
+		[]sql.Row{{int64(2)}},
+	},
+	{
 		"SELECT i FROM mytable WHERE i > 2;",
 		[]sql.Row{{int64(3)}},
 	},
 	{
+		"SELECT i FROM mytable WHERE 2 < i;",
+		[]sql.Row{{int64(3)}},
+	},
+	{
 		"SELECT i FROM mytable WHERE i < 2;",
+		[]sql.Row{{int64(1)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE 2 > i;",
 		[]sql.Row{{int64(1)}},
 	},
 	{
@@ -218,7 +230,15 @@ var QueryTests = []QueryTest{
 		[]sql.Row{{int64(2)}, {int64(3)}},
 	},
 	{
+		"SELECT i FROM mytable WHERE 2 <= i ORDER BY 1",
+		[]sql.Row{{int64(2)}, {int64(3)}},
+	},
+	{
 		"SELECT i FROM mytable WHERE i <= 2 ORDER BY 1",
+		[]sql.Row{{int64(1)}, {int64(2)}},
+	},
+	{
+		"SELECT i FROM mytable WHERE 2 >= i ORDER BY 1",
 		[]sql.Row{{int64(1)}, {int64(2)}},
 	},
 	{

--- a/enginetest/query_plans.go
+++ b/enginetest/query_plans.go
@@ -88,7 +88,7 @@ var PlanTests = []QueryPlanTest{
 		Query: "SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2",
 		ExpectedPlan: "IndexedJoin(mt.i = ot.i2)\n" +
 				" ├─ TableAlias(mt)\n" +
-				" │   └─ Table(mytable): Projected Filtered \n" +
+				" │   └─ Table(mytable): Projected Filtered Indexed\n" +
 				" └─ TableAlias(ot)\n" +
 				"     └─ Table(othertable): Projected \n" +
 				"",

--- a/memory/table.go
+++ b/memory/table.go
@@ -654,7 +654,7 @@ func (t *Table) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
 				idx, field := t.getField(column.Name)
 				exprs[i] = expression.NewGetFieldWithTable(idx, field.Type, t.name, field.Name, field.Nullable)
 			}
-			indexes = append(indexes, &UnmergeableIndex{
+			indexes = append(indexes, &MergeableIndex{
 				DB:         "",
 				DriverName: "native",
 				Tbl:        t,
@@ -683,11 +683,13 @@ func (t *Table) createIndex(name string, columns []sql.IndexColumn) (sql.Index, 
 	}
 
 	return &UnmergeableIndex{
-		DB:         "",
-		DriverName: "native",
-		Tbl:        t,
-		TableName:  t.name,
-		Exprs:      exprs,
+		MergeableIndex{
+			DB:         "",
+			DriverName: "native",
+			Tbl:        t,
+			TableName:  t.name,
+			Exprs:      exprs,
+		},
 	}, nil
 }
 

--- a/memory/unmergeable_index.go
+++ b/memory/unmergeable_index.go
@@ -53,7 +53,7 @@ func (u *UnmergeableIndexLookup) Difference(_ ...sql.IndexLookup) sql.IndexLooku
 var _ sql.IndexLookup = (*UnmergeableIndexLookup)(nil)
 var _ sql.MergeableIndexLookup = (*UnmergeableIndexLookup)(nil)
 
-// dummyIndexValueIter does a very simple and verifiable iteration over the table values for a given index. It does this
+// indexValIter does a very simple and verifiable iteration over the table values for a given index. It does this
 // by iterating over all the table rows for a partition and evaluating each of them for inclusion in the index. This is
 // not an efficient way to store an index, and is only suitable for testing the correctness of index code in the engine.
 type indexValIter struct {

--- a/sql/analyzer/indexes_test.go
+++ b/sql/analyzer/indexes_test.go
@@ -87,9 +87,11 @@ func TestAssignIndexes(t *testing.T) {
 	<-ready
 
 	idx3 := &memory.UnmergeableIndex{
-		TableName: "t1",
-		Exprs: []sql.Expression{
-			expression.NewGetFieldWithTable(0, sql.Int64, "t1", "bar", false),
+		memory.MergeableIndex{
+			TableName: "t1",
+			Exprs: []sql.Expression{
+				expression.NewGetFieldWithTable(0, sql.Int64, "t1", "bar", false),
+			},
 		},
 	}
 
@@ -264,9 +266,11 @@ func TestGetIndexes(t *testing.T) {
 			},
 		},
 		&memory.UnmergeableIndex{
-			TableName: "t3",
-			Exprs: []sql.Expression{
-				col(0, "t3", "foo"),
+			memory.MergeableIndex{
+				TableName: "t3",
+				Exprs: []sql.Expression{
+					col(0, "t3", "foo"),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixed bug in ascend / descend index lookups, added engine tests for same. Also realized that the in-memory unmergeable index implementation didn't support ascened / descend, so fixed that.