### PR TITLE
Orderable query results with lazy expression evaluation

### DIFF
--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -41,6 +41,14 @@ func (i *IndexedTableAccess) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	return sql.NewTableRowIter(ctx, i.indexedTable, partIter), nil
 }
 
+func (i *IndexedTableAccess) OrderableIter(ctx *sql.Context) (OrderableIter, error) {
+	iter, err := i.RowIter(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &orderableTableIter{iter.(*sql.TableRowIter)}, nil
+}
+
 func (i *IndexedTableAccess) WithChildren(children ...sql.Node) (sql.Node, error) {
 	if len(children) != 1 {
 		return nil, sql.ErrInvalidChildrenNumber.New(i, len(children), 1)
@@ -61,3 +69,4 @@ func NewIndexedTable(resolvedTable *ResolvedTable) *IndexedTableAccess {
 }
 
 var _ sql.Node = (*IndexedTableAccess)(nil)
+var _ OrderableNode = (*IndexedTableAccess)(nil)

--- a/sql/plan/orderable.go
+++ b/sql/plan/orderable.go
@@ -1,0 +1,49 @@
+package plan
+
+import (
+	"errors"
+	"github.com/liquidata-inc/go-mysql-server/sql"
+	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+)
+
+var ErrIterUnorderable = errors.New("row iter tree is not orderable")
+
+type OrderableNode interface {
+	sql.Node
+	OrderableIter(ctx *sql.Context) (OrderableIter, error)
+}
+
+type OrderableIter interface {
+	sql.RowIter
+	RowOrder() []SortField
+	LazyProjections() []sql.Expression
+}
+
+type orderableTableIter struct {
+	*sql.TableRowIter
+}
+
+var _ OrderableIter = (*orderableTableIter)(nil)
+
+func (i *orderableTableIter) RowOrder() []SortField {
+	var fields []SortField
+	for idx, col := range i.TableRowIter.Schema() {
+		if !col.PrimaryKey {
+			continue
+		}
+		fields = append(fields, SortField{
+			Column: expression.NewGetField(idx, col.Type, col.Name, col.Nullable),
+			Order: Ascending,
+			NullOrdering: NullsFirst,
+		})
+	}
+	return fields
+}
+
+func (i *orderableTableIter) LazyProjections() []sql.Expression {
+	getFields := make([]sql.Expression, len(i.TableRowIter.Schema()))
+	for i, col := range i.TableRowIter.Schema() {
+		getFields[i] = expression.NewGetField(i, col.Type, col.Name, col.Nullable)
+	}
+	return getFields
+}

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -10,6 +10,7 @@ type ResolvedTable struct {
 }
 
 var _ sql.Node = (*ResolvedTable)(nil)
+var _ OrderableNode = (*ResolvedTable)(nil)
 
 // NewResolvedTable creates a new instance of ResolvedTable.
 func NewResolvedTable(table sql.Table) *ResolvedTable {
@@ -35,6 +36,15 @@ func (t *ResolvedTable) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 	}
 
 	return sql.NewSpanIter(span, sql.NewTableRowIter(ctx, t.Table, partitions)), nil
+}
+
+func (t *ResolvedTable) OrderableIter(ctx *sql.Context) (OrderableIter, error) {
+	partitions, err := t.Table.Partitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &orderableTableIter{sql.NewTableRowIter(ctx, t.Table, partitions)}, nil
 }
 
 // WithChildren implements the Node interface.

--- a/sql/table_iter.go
+++ b/sql/table_iter.go
@@ -19,6 +19,10 @@ func NewTableRowIter(ctx *Context, table Table, partitions PartitionIter) *Table
 	return &TableRowIter{ctx: ctx, table: table, partitions: partitions}
 }
 
+func (i *TableRowIter) Schema() Schema {
+	return i.table.Schema()
+}
+
 func (i *TableRowIter) Next() (Row, error) {
 	select {
 	case <-i.ctx.Done():


### PR DESCRIPTION
@zachmu having now torn this all up, I think I can actually do this with an analysis step. 

The current approach is: 
 - traverse the query plan from the bottom up, chaining together `orderableIter`s along the way
 - collect any projections you find
 - transform `Expression`s that rely on those projections (`Filter`, `Sort`, `Having`)
 - collect `SortFields` to later compare row order

These would probably be easier if they were done using `TransformUp`. You could just remove the `Project` nodes, save their projections, and transform dependent `Expression`s in the same way. Let me know what you think.
