### PR TITLE
Lower-case types in SHOW CREATE TABLE and DESCRIBE TABLE output. This…

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1259,13 +1259,13 @@ var QueryTests = []QueryTest{
 		[]sql.Row{{
 			"two_pk",
 			"CREATE TABLE `two_pk` (\n" +
-				"  `pk1` TINYINT NOT NULL,\n" +
-				"  `pk2` TINYINT NOT NULL,\n" +
-				"  `c1` TINYINT NOT NULL,\n" +
-				"  `c2` TINYINT NOT NULL,\n" +
-				"  `c3` TINYINT NOT NULL,\n" +
-				"  `c4` TINYINT NOT NULL,\n" +
-				"  `c5` TINYINT NOT NULL,\n" +
+				"  `pk1` tinyint NOT NULL,\n" +
+				"  `pk2` tinyint NOT NULL,\n" +
+				"  `c1` tinyint NOT NULL,\n" +
+				"  `c2` tinyint NOT NULL,\n" +
+				"  `c3` tinyint NOT NULL,\n" +
+				"  `c4` tinyint NOT NULL,\n" +
+				"  `c5` tinyint NOT NULL,\n" +
 				"  PRIMARY KEY (`pk1`,`pk2`)\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 		}},
@@ -2479,41 +2479,41 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		`SHOW COLUMNS FROM mytable`,
 		[]sql.Row{
-			{"i", "BIGINT", "NO", "PRI", "", ""},
-			{"s", "VARCHAR(20)", "NO", "UNI", "", ""},
+			{"i", "bigint", "NO", "PRI", "", ""},
+			{"s", "varchar(20)", "NO", "UNI", "", ""},
 		},
 	},
 	{
 		`DESCRIBE mytable`,
 		[]sql.Row{
-			{"i", "BIGINT", "NO", "PRI", "", ""},
-			{"s", "VARCHAR(20)", "NO", "UNI", "", ""},
+			{"i", "bigint", "NO", "PRI", "", ""},
+			{"s", "varchar(20)", "NO", "UNI", "", ""},
 		},
 	},
 	{
 		`DESC mytable`,
 		[]sql.Row{
-			{"i", "BIGINT", "NO", "PRI", "", ""},
-			{"s", "VARCHAR(20)", "NO", "UNI", "", ""},
+			{"i", "bigint", "NO", "PRI", "", ""},
+			{"s", "varchar(20)", "NO", "UNI", "", ""},
 		},
 	},
 	{
 		`SHOW COLUMNS FROM mytable WHERE Field = 'i'`,
 		[]sql.Row{
-			{"i", "BIGINT", "NO", "PRI", "", ""},
+			{"i", "bigint", "NO", "PRI", "", ""},
 		},
 	},
 	{
 		`SHOW COLUMNS FROM mytable LIKE 'i'`,
 		[]sql.Row{
-			{"i", "BIGINT", "NO", "PRI", "", ""},
+			{"i", "bigint", "NO", "PRI", "", ""},
 		},
 	},
 	{
 		`SHOW FULL COLUMNS FROM mytable`,
 		[]sql.Row{
-			{"i", "BIGINT", nil, "NO", "PRI", "", "", "", ""},
-			{"s", "VARCHAR(20)", "utf8_bin", "NO", "UNI", "", "", "", "column s"},
+			{"i", "bigint", nil, "NO", "PRI", "", "", "", ""},
+			{"s", "varchar(20)", "utf8_bin", "NO", "UNI", "", "", "", "column s"},
 		},
 	},
 	{
@@ -2663,8 +2663,8 @@ var InfoSchemaQueries = []QueryTest{
 		`SHOW CREATE TABLE mytaBLE`,
 		[]sql.Row{
 			{"mytable", "CREATE TABLE `mytable` (\n" +
-				"  `i` BIGINT NOT NULL,\n" +
-				"  `s` VARCHAR(20) NOT NULL COMMENT 'column s',\n" +
+				"  `i` bigint NOT NULL,\n" +
+				"  `s` varchar(20) NOT NULL COMMENT 'column s',\n" +
 				"  PRIMARY KEY (`i`),\n" +
 				"  KEY `mytable_i_s` (`i`,`s`),\n" +
 				"  UNIQUE KEY `mytable_s` (`s`)\n" +
@@ -2675,9 +2675,9 @@ var InfoSchemaQueries = []QueryTest{
 		`SHOW CREATE TABLE fk_TBL`,
 		[]sql.Row{
 			{"fk_tbl", "CREATE TABLE `fk_tbl` (\n" +
-				"  `pk` BIGINT NOT NULL,\n" +
-				"  `a` BIGINT,\n" +
-				"  `b` VARCHAR(20),\n" +
+				"  `pk` bigint NOT NULL,\n" +
+				"  `a` bigint,\n" +
+				"  `b` varchar(20),\n" +
 				"  PRIMARY KEY (`pk`),\n" +
 				"  CONSTRAINT `fk1` FOREIGN KEY (`a`,`b`) REFERENCES `mytable` (`i`,`s`) ON DELETE CASCADE\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"},

--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -147,8 +147,9 @@ func (i *showCreateTablesIter) produceCreateTableStatement(table sql.Table) (str
 	var primaryKeyCols []string
 
 	// Statement creation parts for each column
+	// TODO: rather than lower-casing here, we should do it in the String() method of types
 	for i, col := range schema {
-		stmt := fmt.Sprintf("  `%s` %s", col.Name, col.Type.String())
+		stmt := fmt.Sprintf("  `%s` %s", col.Name, strings.ToLower(col.Type.String()))
 
 		if !col.Nullable {
 			stmt = fmt.Sprintf("%s NOT NULL", stmt)

--- a/sql/plan/show_create_table_test.go
+++ b/sql/plan/show_create_table_test.go
@@ -42,11 +42,11 @@ func TestShowCreateTable(t *testing.T) {
 
 	expected := sql.NewRow(
 		table.Name(),
-		"CREATE TABLE `test-table` (\n  `baz` TEXT NOT NULL,\n"+
-			"  `zab` INT DEFAULT 0,\n"+
-			"  `bza` BIGINT UNSIGNED DEFAULT 0 COMMENT 'hello',\n"+
-			"  `foo` VARCHAR(123),\n"+
-			"  `pok` CHAR(123),\n"+
+		"CREATE TABLE `test-table` (\n  `baz` text NOT NULL,\n"+
+			"  `zab` int DEFAULT 0,\n"+
+			"  `bza` bigint unsigned DEFAULT 0 COMMENT 'hello',\n"+
+			"  `foo` varchar(123),\n"+
+			"  `pok` char(123),\n"+
 			"  PRIMARY KEY (`baz`,`zab`)\n"+
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 	)
@@ -119,11 +119,11 @@ func TestShowCreateTableWithIndexAndForeignKeys(t *testing.T) {
 
 	expected := sql.NewRow(
 		table.Name(),
-		"CREATE TABLE `test-table` (\n  `baz` TEXT NOT NULL,\n"+
-			"  `zab` INT DEFAULT 0,\n"+
-			"  `bza` BIGINT UNSIGNED DEFAULT 0 COMMENT 'hello',\n"+
-			"  `foo` VARCHAR(123),\n"+
-			"  `pok` CHAR(123),\n"+
+		"CREATE TABLE `test-table` (\n  `baz` text NOT NULL,\n"+
+			"  `zab` int DEFAULT 0,\n"+
+			"  `bza` bigint unsigned DEFAULT 0 COMMENT 'hello',\n"+
+			"  `foo` varchar(123),\n"+
+			"  `pok` char(123),\n"+
 			"  PRIMARY KEY (`baz`,`zab`),\n"+
 			"  UNIQUE KEY `qux` (`foo`),\n"+
 			"  KEY `zug` (`pok`,`foo`),\n"+

--- a/sql/plan/showcolumns.go
+++ b/sql/plan/showcolumns.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/liquidata-inc/go-mysql-server/sql"
 )
@@ -90,10 +91,11 @@ func (s *ShowColumns) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 			defaultVal = fmt.Sprint(col.Default)
 		}
 
+		// TODO: rather than lower-casing here, we should lower-case the String() method of types
 		if s.Full {
 			row = sql.Row{
 				col.Name,
-				col.Type.String(),
+				strings.ToLower(col.Type.String()),
 				collation,
 				null,
 				key, // Key
@@ -105,7 +107,7 @@ func (s *ShowColumns) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		} else {
 			row = sql.Row{
 				col.Name,
-				col.Type.String(),
+				strings.ToLower(col.Type.String()),
 				null,
 				key,
 				defaultVal,

--- a/sql/plan/showcolumns_test.go
+++ b/sql/plan/showcolumns_test.go
@@ -26,9 +26,9 @@ func TestShowColumns(t *testing.T) {
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{"a", "TEXT", "NO", "PRI", "", ""},
-		{"b", "BIGINT", "YES", "", "", ""},
-		{"c", "BIGINT", "NO", "", "1", ""},
+		{"a", "text", "NO", "PRI", "", ""},
+		{"b", "bigint", "YES", "", "", ""},
+		{"c", "bigint", "NO", "", "1", ""},
 	}
 
 	require.Equal(expected, rows)
@@ -78,11 +78,11 @@ func TestShowColumnsWithIndexes(t *testing.T) {
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{"a", "TEXT", "NO", "PRI", "", ""},
-		{"b", "BIGINT", "YES", "UNI", "", ""},
-		{"c", "BIGINT", "NO", "", "1", ""},
-		{"d", "BIGINT", "YES", "MUL", "", ""},
-		{"e", "BIGINT", "NO", "", "1", ""},
+		{"a", "text", "NO", "PRI", "", ""},
+		{"b", "bigint", "YES", "UNI", "", ""},
+		{"c", "bigint", "NO", "", "1", ""},
+		{"d", "bigint", "YES", "MUL", "", ""},
+		{"e", "bigint", "NO", "", "1", ""},
 	}
 
 	require.Equal(expected, rows)
@@ -136,9 +136,9 @@ func TestShowColumnsFull(t *testing.T) {
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{"a", "TEXT", "utf8_bin", "NO", "PRI", "", "", "", ""},
-		{"b", "BIGINT", nil, "YES", "", "", "", "", ""},
-		{"c", "BIGINT", nil, "NO", "", "1", "", "", "a comment"},
+		{"a", "text", "utf8_bin", "NO", "PRI", "", "", "", ""},
+		{"b", "bigint", nil, "YES", "", "", "", "", ""},
+		{"c", "bigint", nil, "NO", "", "1", "", "", "a comment"},
 	}
 
 	require.Equal(expected, rows)


### PR DESCRIPTION
… matches MySQL behavior, and is required by at least one third-party tool (SqlAlchemy)

Signed-off-by: Zach Musgrave <zach@liquidata.co>