### PR TITLE
Fixed panic when using non-literals as column defaults

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -657,6 +657,12 @@ func TestCreateTable(t *testing.T, harness Harness) {
 		"c bool, primary key (a))")
 	require.Error(err)
 	require.True(sql.ErrTableAlreadyExists.Is(err))
+
+	_, _, err = e.Query(NewContext(harness), "CREATE TABLE t10(a INTEGER,"+
+			"`create_time` timestamp(6) NOT NULL DEFAULT NOW(),"+
+			"primary key (a))")
+	require.Error(err)
+	require.True(sql.ErrUnsupportedDefault.Is(err))
 }
 
 func TestDropTable(t *testing.T, harness Harness) {

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -65,5 +65,8 @@ var (
 		" this projection with that name. Aliases cannot be used in the same projection they're defined in")
 
 	// ErrInvalidAsOfExpression is returned when an expression for AS OF cannot be used
-	ErrInvalidAsOfExpression = errors.NewKind("Expression %s cannot be used in AS OF")
+	ErrInvalidAsOfExpression = errors.NewKind("expression %s cannot be used in AS OF")
+
+	// ErrUnsupportedDefault return when an expression for a column default is not supported
+	ErrUnsupportedDefault = errors.NewKind("column default %s is not supported")
 )

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -978,6 +978,9 @@ func columnDefinitionToColumn(ctx *sql.Context, cd *sqlparser.ColumnDefinition, 
 		// TODO: this isn't quite right -- some default expressions here (like function calls) need to be stored by the
 		//  implementor and deferred until row insertion time. We can't do that, but we can at least do a better job
 		//  detecting when this happens and erroring out.
+		if !dflt.Resolved() {
+			return nil, sql.ErrUnsupportedDefault.New(dflt.String())
+		}
 		defaultVal, err = dflt.Eval(ctx, nil)
 		if err != nil {
 			return nil, ErrUnsupportedFeature.New("column defaults must be evaluable at schema modification time")


### PR DESCRIPTION
This fixes #104 