### PR TITLE
[DRAFT] Column Defaults

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1178,9 +1178,9 @@ var QueryTests = []QueryTest{
 	{
 		`SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA`,
 		[]sql.Row{
-			{"information_schema", "utf8mb4", "utf8_bin"},
-			{"mydb", "utf8mb4", "utf8_bin"},
-			{"foo", "utf8mb4", "utf8_bin"},
+			{"information_schema", "utf8mb4", "utf8mb4_0900_ai_ci"},
+			{"mydb", "utf8mb4", "utf8mb4_0900_ai_ci"},
+			{"foo", "utf8mb4", "utf8mb4_0900_ai_ci"},
 		},
 	},
 	{
@@ -1237,7 +1237,7 @@ var QueryTests = []QueryTest{
 			{"max_allowed_packet", math.MaxInt32},
 			{"sql_mode", ""},
 			{"gtid_mode", int32(0)},
-			{"collation_database", "utf8_bin"},
+			{"collation_database", "utf8mb4_0900_ai_ci"},
 			{"ndbinfo_version", ""},
 			{"sql_select_limit", math.MaxInt32},
 			{"transaction_isolation", "READ UNCOMMITTED"},
@@ -1292,7 +1292,7 @@ var QueryTests = []QueryTest{
 		`SHOW CREATE DATABASE mydb`,
 		[]sql.Row{{
 			"mydb",
-			"CREATE DATABASE `mydb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */",
+			"CREATE DATABASE `mydb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */",
 		}},
 	},
 	{
@@ -1501,7 +1501,7 @@ var QueryTests = []QueryTest{
 	},
 	{
 		`SHOW COLLATION`,
-		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1), "PAD SPACE"}},
+		[]sql.Row{{"utf8mb4_0900_ai_ci", "utf8mb4", int64(1), "Yes", "Yes", int64(1), "PAD SPACE"}},
 	},
 	{
 		`SHOW COLLATION LIKE 'foo'`,
@@ -1509,7 +1509,7 @@ var QueryTests = []QueryTest{
 	},
 	{
 		`SHOW COLLATION LIKE 'utf8%'`,
-		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1), "PAD SPACE"}},
+		[]sql.Row{{"utf8mb4_0900_ai_ci", "utf8mb4", int64(1), "Yes", "Yes", int64(1), "PAD SPACE"}},
 	},
 	{
 		`SHOW COLLATION WHERE charset = 'foo'`,
@@ -1517,7 +1517,7 @@ var QueryTests = []QueryTest{
 	},
 	{
 		"SHOW COLLATION WHERE `Default` = 'Yes'",
-		[]sql.Row{{"utf8_bin", "utf8mb4", int64(1), "Yes", "Yes", int64(1), "PAD SPACE"}},
+		[]sql.Row{{"utf8mb4_0900_ai_ci", "utf8mb4", int64(1), "Yes", "Yes", int64(1), "PAD SPACE"}},
 	},
 	{
 		"ROLLBACK",
@@ -2948,44 +2948,44 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		`SHOW TABLE STATUS FROM mydb`,
 		[]sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"floattable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"fk_tbl", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"niltable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"newlinetable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"floattable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"fk_tbl", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"niltable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"newlinetable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 		},
 	},
 	{
 		`SHOW TABLE STATUS LIKE '%table'`,
 		[]sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"floattable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"niltable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"newlinetable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"floattable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"niltable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"newlinetable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 		},
 	},
 	{
 		`SHOW TABLE STATUS WHERE Name = 'mytable'`,
 		[]sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 		},
 	},
 	{
 		`SHOW TABLE STATUS`,
 		[]sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"fk_tbl", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"floattable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"niltable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-			{"newlinetable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"bigtable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"fk_tbl", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"floattable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"niltable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
+			{"newlinetable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 		},
 	},
 	{
@@ -3070,7 +3070,7 @@ var InfoSchemaQueries = []QueryTest{
 		`SHOW FULL COLUMNS FROM mytable`,
 		[]sql.Row{
 			{"i", "bigint", nil, "NO", "PRI", "", "", "", ""},
-			{"s", "varchar(20)", "utf8_bin", "NO", "UNI", "", "", "", "column s"},
+			{"s", "varchar(20)", "utf8mb4_0900_ai_ci", "NO", "UNI", "", "", "", "column s"},
 		},
 	},
 	{
@@ -3493,8 +3493,8 @@ var ViewTests = []QueryTest{
 	{
 		"select * from information_schema.views where table_schema = 'mydb'",
 		[]sql.Row{
-			sql.NewRow("def", "mydb", "myview", "SELECT * FROM mytable", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8_bin"),
-			sql.NewRow("def", "mydb", "myview2", "SELECT * FROM myview WHERE i = 1", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8_bin"),
+			sql.NewRow("def", "mydb", "myview", "SELECT * FROM mytable", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8mb4_0900_ai_ci"),
+			sql.NewRow("def", "mydb", "myview2", "SELECT * FROM myview WHERE i = 1", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8mb4_0900_ai_ci"),
 		},
 	},
 	{
@@ -3585,9 +3585,9 @@ var VersionedViewTests = []QueryTest{
 	{
 		"select * from information_schema.views where table_schema = 'mydb'",
 		[]sql.Row{
-			sql.NewRow("def", "mydb", "myview", "SELECT * FROM mytable", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8_bin"),
-			sql.NewRow("def", "mydb", "myview1", "SELECT * FROM myhistorytable", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8_bin"),
-			sql.NewRow("def", "mydb", "myview2", "SELECT * FROM myview1 WHERE i = 1", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8_bin"),
+			sql.NewRow("def", "mydb", "myview", "SELECT * FROM mytable", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8mb4_0900_ai_ci"),
+			sql.NewRow("def", "mydb", "myview1", "SELECT * FROM myhistorytable", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8mb4_0900_ai_ci"),
+			sql.NewRow("def", "mydb", "myview2", "SELECT * FROM myview1 WHERE i = 1", "NONE", "YES", "", "DEFINER", "utf8mb4", "utf8mb4_0900_ai_ci"),
 		},
 	},
 	{

--- a/memory/table.go
+++ b/memory/table.go
@@ -461,8 +461,12 @@ func (t *Table) AddColumn(ctx *sql.Context, column *sql.Column, order *sql.Colum
 	}
 
 	t.schema = newSch
-	// TODO: only do if the column is declared not null?
-	t.insertValueInRows(newColIdx, column.Default)
+	// TODO: each row must separately evaluate the default
+	val, err := column.Default.Eval(ctx, nil)
+	if err != nil {
+		return err
+	}
+	t.insertValueInRows(newColIdx, val)
 	return nil
 }
 

--- a/memory/table_test.go
+++ b/memory/table_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	"github.com/liquidata-inc/go-mysql-server/sql/parse"
 )
 
 func TestTablePartitionsCount(t *testing.T) {
@@ -112,9 +113,9 @@ var tests = []struct {
 	{
 		name: "test",
 		schema: sql.Schema{
-			&sql.Column{Name: "col1", Source: "test", Type: sql.Text, Nullable: false, Default: ""},
-			&sql.Column{Name: "col2", Source: "test", Type: sql.Int32, Nullable: false, Default: int32(0)},
-			&sql.Column{Name: "col3", Source: "test", Type: sql.Int64, Nullable: false, Default: int64(0)},
+			&sql.Column{Name: "col1", Source: "test", Type: sql.Text, Nullable: false, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), `""`)},
+			&sql.Column{Name: "col2", Source: "test", Type: sql.Int32, Nullable: false, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), "0")},
+			&sql.Column{Name: "col3", Source: "test", Type: sql.Int64, Nullable: false, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), "0")},
 		},
 		numPartitions: 2,
 		rows: []sql.Row{
@@ -138,8 +139,8 @@ var tests = []struct {
 		},
 		columns: []string{"col3", "col1"},
 		expectedSchema: sql.Schema{
-			&sql.Column{Name: "col3", Source: "test", Type: sql.Int64, Nullable: false, Default: int64(0)},
-			&sql.Column{Name: "col1", Source: "test", Type: sql.Text, Nullable: false, Default: ""},
+			&sql.Column{Name: "col3", Source: "test", Type: sql.Int64, Nullable: false, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), "0")},
+			&sql.Column{Name: "col1", Source: "test", Type: sql.Text, Nullable: false, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), `""`)},
 		},
 		expectedProjected: []sql.Row{
 			sql.NewRow(int64(100), "a"),

--- a/sql/column.go
+++ b/sql/column.go
@@ -11,8 +11,8 @@ type Column struct {
 	Name string
 	// Type is the data type of the column.
 	Type Type
-	// Default contains the default value of the column or nil if it is NULL.
-	Default interface{}
+	// Default contains the default value of the column or nil if it was not explicitly defined. A nil instance is valid, thus calls do not error.
+	Default *ColumnDefaultValue
 	// Nullable is true if the column can contain NULL values, or false
 	// otherwise.
 	Nullable bool

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -1,0 +1,96 @@
+package sql
+
+import (
+	"fmt"
+)
+
+// ColumnDefaultValue is an expression representing the default value of a column. May represent both a default literal
+// and a default expression. A nil pointer of this type represents an implicit default value and is thus valid, so all
+// method calls will return without error.
+type ColumnDefaultValue struct {
+	Expression
+	literal bool
+}
+
+var _ Expression = (*ColumnDefaultValue)(nil)
+
+// NewColumnDefaultValue returns a new ColumnDefaultValue expression.
+func NewColumnDefaultValue(expr Expression, representsLiteral bool) *ColumnDefaultValue {
+	return &ColumnDefaultValue{
+		Expression: expr,
+		literal:    representsLiteral,
+	}
+}
+
+// Children implements sql.Expression
+func (e *ColumnDefaultValue) Children() []Expression {
+	if e == nil {
+		return nil
+	}
+	return []Expression{e.Expression}
+}
+
+// Eval implements sql.Expression
+func (e *ColumnDefaultValue) Eval(ctx *Context, r Row) (interface{}, error) {
+	if e == nil {
+		return nil, nil
+	}
+	return e.Expression.Eval(ctx, r)
+}
+
+// IsLiteral returns whether this expression represents a literal default value (otherwise it's an expression default value).
+func (e *ColumnDefaultValue) IsLiteral() bool {
+	if e == nil {
+		return true // we return the literal nil, hence true
+	}
+	return e.literal
+}
+
+// IsNullable implements sql.Expression
+func (e *ColumnDefaultValue) IsNullable() bool {
+	if e == nil {
+		return true
+	}
+	return e.Expression.IsNullable()
+}
+
+// Resolved implements sql.Expression
+func (e *ColumnDefaultValue) Resolved() bool {
+	if e == nil {
+		return true
+	}
+	return e.Expression.Resolved()
+}
+
+// String implements sql.Expression
+func (e *ColumnDefaultValue) String() string {
+	if e == nil {
+		return ""
+	}
+	if e.literal {
+		return e.Expression.String()
+	} else {
+		return fmt.Sprintf("(%s)", e.Expression.String())
+	}
+}
+
+// Type implements sql.Expression
+func (e *ColumnDefaultValue) Type() Type {
+	if e == nil {
+		return Null
+	}
+	return e.Expression.Type()
+}
+
+// WithChildren implements sql.Expression
+func (e *ColumnDefaultValue) WithChildren(children ...Expression) (Expression, error) {
+	if len(children) != 1 {
+		return nil, ErrInvalidChildrenNumber.New(e, len(children), 1)
+	}
+	if e == nil {
+		return NewColumnDefaultValue(children[0], len(children[0].Children()) == 0), nil //impossible to know, best guess
+	} else {
+		return NewColumnDefaultValue(children[0], e.literal), nil
+	}
+}
+

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1,10 +1,13 @@
-package sql
+package information_schema
 
 import (
 	"bytes"
 	"fmt"
 	"io"
 	"strings"
+
+	. "github.com/liquidata-inc/go-mysql-server/sql"
+	"github.com/liquidata-inc/go-mysql-server/sql/parse"
 )
 
 const (
@@ -40,11 +43,6 @@ const (
 	ViewsTableName = "views"
 	// UserPrivilegesTableName is the name of the user_privileges table
 	UserPrivilegesTableName = "user_privileges"
-)
-
-const (
-	DefaultCollation    = "utf8_bin"
-	DefaultCharacterSet = "utf8mb4"
 )
 
 var _ Database = (*informationSchemaDatabase)(nil)
@@ -126,10 +124,10 @@ var columnStatisticsSchema = Schema{
 }
 
 var tablesSchema = Schema{
-	{Name: "table_catalog", Type: LongText, Default: "", Nullable: false, Source: TablesTableName},
-	{Name: "table_schema", Type: LongText, Default: "", Nullable: false, Source: TablesTableName},
-	{Name: "table_name", Type: LongText, Default: "", Nullable: false, Source: TablesTableName},
-	{Name: "table_type", Type: LongText, Default: "", Nullable: false, Source: TablesTableName},
+	{Name: "table_catalog", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: TablesTableName},
+	{Name: "table_schema", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: TablesTableName},
+	{Name: "table_name", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: TablesTableName},
+	{Name: "table_type", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: TablesTableName},
 	{Name: "engine", Type: LongText, Default: nil, Nullable: true, Source: TablesTableName},
 	{Name: "version", Type: Uint64, Default: nil, Nullable: true, Source: TablesTableName},
 	{Name: "row_format", Type: LongText, Default: nil, Nullable: true, Source: TablesTableName},
@@ -146,18 +144,18 @@ var tablesSchema = Schema{
 	{Name: "table_collation", Type: LongText, Default: nil, Nullable: true, Source: TablesTableName},
 	{Name: "checksum", Type: Uint64, Default: nil, Nullable: true, Source: TablesTableName},
 	{Name: "create_options", Type: LongText, Default: nil, Nullable: true, Source: TablesTableName},
-	{Name: "table_comment", Type: LongText, Default: "", Nullable: false, Source: TablesTableName},
+	{Name: "table_comment", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: TablesTableName},
 }
 
 var columnsSchema = Schema{
-	{Name: "table_catalog", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "table_schema", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "table_name", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "column_name", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "ordinal_position", Type: Uint64, Default: 0, Nullable: false, Source: ColumnsTableName},
+	{Name: "table_catalog", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "table_schema", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "table_name", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "column_name", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "ordinal_position", Type: Uint64, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), "0"), Nullable: false, Source: ColumnsTableName},
 	{Name: "column_default", Type: LongText, Default: nil, Nullable: true, Source: ColumnsTableName},
-	{Name: "is_nullable", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "data_type", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
+	{Name: "is_nullable", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "data_type", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
 	{Name: "character_maximum_length", Type: Uint64, Default: nil, Nullable: true, Source: ColumnsTableName},
 	{Name: "character_octet_length", Type: Uint64, Default: nil, Nullable: true, Source: ColumnsTableName},
 	{Name: "numeric_precision", Type: Uint64, Default: nil, Nullable: true, Source: ColumnsTableName},
@@ -165,12 +163,12 @@ var columnsSchema = Schema{
 	{Name: "datetime_precision", Type: Uint64, Default: nil, Nullable: true, Source: ColumnsTableName},
 	{Name: "character_set_name", Type: LongText, Default: nil, Nullable: true, Source: ColumnsTableName},
 	{Name: "collation_name", Type: LongText, Default: nil, Nullable: true, Source: ColumnsTableName},
-	{Name: "column_type", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "column_key", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "extra", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "privileges", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "column_comment", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
-	{Name: "generation_expression", Type: LongText, Default: "", Nullable: false, Source: ColumnsTableName},
+	{Name: "column_type", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "column_key", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "extra", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "privileges", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "column_comment", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
+	{Name: "generation_expression", Type: LongText, Default: parse.MustStringToColumnDefaultValue(NewEmptyContext(), `""`), Nullable: false, Source: ColumnsTableName},
 }
 
 var schemataSchema = Schema{
@@ -371,27 +369,27 @@ func tablesRowIter(ctx *Context, cat *Catalog) RowIter {
 
 		err := DBTableIter(ctx, db, func(t Table) (cont bool, err error) {
 			rows = append(rows, Row{
-				"def",            // table_catalog
-				db.Name(),        // table_schema
-				t.Name(),         // table_name
-				tableType,        // table_type
-				engine,           // engine
-				10,               // version (protocol, always 10)
-				rowFormat,        // row_format
-				nil,              // table_rows
-				nil,              // avg_row_length
-				nil,              // data_length
-				nil,              // max_data_length
-				nil,              // max_data_length
-				nil,              // data_free
-				nil,              // auto_increment
-				nil,              // create_time
-				nil,              // update_time
-				nil,              // check_time
-				DefaultCollation, // table_collation
-				nil,              // checksum
-				nil,              // create_options
-				"",               // table_comment
+				"def",                      // table_catalog
+				db.Name(),                  // table_schema
+				t.Name(),                   // table_name
+				tableType,                  // table_type
+				engine,                     // engine
+				10,                         // version (protocol, always 10)
+				rowFormat,                  // row_format
+				nil,                        // table_rows
+				nil,                        // avg_row_length
+				nil,                        // data_length
+				nil,                        // max_data_length
+				nil,                        // max_data_length
+				nil,                        // data_free
+				nil,                        // auto_increment
+				nil,                        // create_time
+				nil,                        // update_time
+				nil,                        // check_time
+				Collation_Default.String(), // table_collation
+				nil,                        // checksum
+				nil,                        // create_options
+				"",                         // table_comment
 			})
 
 			return true, nil
@@ -399,27 +397,27 @@ func tablesRowIter(ctx *Context, cat *Catalog) RowIter {
 
 		for _, view := range ctx.ViewsInDatabase(db.Name()) {
 			rows = append(rows, Row{
-				"def",            // table_catalog
-				db.Name(),        // table_schema
-				view.Name(),      // table_name
-				"VIEW",           // table_type
-				engine,           // engine
-				10,               // version (protocol, always 10)
-				rowFormat,        // row_format
-				nil,              // table_rows
-				nil,              // avg_row_length
-				nil,              // data_length
-				nil,              // max_data_length
-				nil,              // max_data_length
-				nil,              // data_free
-				nil,              // auto_increment
-				nil,              // create_time
-				nil,              // update_time
-				nil,              // check_time
-				DefaultCollation, // table_collation
-				nil,              // checksum
-				nil,              // create_options
-				"",               // table_comment
+				"def",                      // table_catalog
+				db.Name(),                  // table_schema
+				view.Name(),                // table_name
+				"VIEW",                     // table_type
+				engine,                     // engine
+				10,                         // version (protocol, always 10)
+				rowFormat,                  // row_format
+				nil,                        // table_rows
+				nil,                        // avg_row_length
+				nil,                        // data_length
+				nil,                        // max_data_length
+				nil,                        // max_data_length
+				nil,                        // data_free
+				nil,                        // auto_increment
+				nil,                        // create_time
+				nil,                        // update_time
+				nil,                        // check_time
+				Collation_Default.String(), // table_collation
+				nil,                        // checksum
+				nil,                        // create_options
+				"",                         // table_comment
 			})
 		}
 
@@ -448,8 +446,8 @@ func columnsRowIter(ctx *Context, cat *Catalog) RowIter {
 					nullable = "NO"
 				}
 				if IsText(c.Type) {
-					charName = "utf8mb4"
-					collName = "utf8_bin"
+					charName = Collation_Default.CharacterSet().String()
+					collName = Collation_Default.String()
 				}
 				rows = append(rows, Row{
 					"def",                            // table_catalog
@@ -457,7 +455,7 @@ func columnsRowIter(ctx *Context, cat *Catalog) RowIter {
 					t.Name(),                         // table_name
 					c.Name,                           // column_name
 					uint64(i),                        // ordinal_position
-					c.Default,                        // column_default
+					c.Default.String(),               // column_default
 					nullable,                         // is_nullable
 					strings.ToLower(c.Type.String()), // data_type
 					nil,                              // character_maximum_length
@@ -494,8 +492,8 @@ func schemataRowIter(ctx *Context, c *Catalog) RowIter {
 		rows = append(rows, Row{
 			"def",
 			db.Name(),
-			"utf8mb4",
-			"utf8_bin",
+			Collation_Default.CharacterSet().String(),
+			Collation_Default.String(),
 			nil,
 		})
 	}
@@ -505,8 +503,8 @@ func schemataRowIter(ctx *Context, c *Catalog) RowIter {
 
 func collationsRowIter(ctx *Context, c *Catalog) RowIter {
 	return RowsToRowIter(Row{
-		DefaultCollation,
-		DefaultCharacterSet,
+		Collation_Default.String(),
+		Collation_Default.CharacterSet().String(),
 		int64(1),
 		"Yes",
 		"Yes",
@@ -618,7 +616,7 @@ func NewInformationSchemaDatabase(cat *Catalog) Database {
 
 func viewRowIter(context *Context, catalog *Catalog) RowIter {
 	var rows []Row
-	for _, db := range catalog.dbs {
+	for _, db := range catalog.AllDatabases() {
 		database := db.Name()
 		for _, view := range context.ViewRegistry.ViewsInDatabase(database) {
 			rows = append(rows, Row{
@@ -630,8 +628,8 @@ func viewRowIter(context *Context, catalog *Catalog) RowIter {
 				"YES",
 				"",
 				"DEFINER",
-				DefaultCharacterSet,
-				DefaultCollation,
+				Collation_Default.CharacterSet().String(),
+				Collation_Default.String(),
 			})
 		}
 	}

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -556,7 +556,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.Int32,
 			Nullable: false,
 			Comment:  "hello",
-			Default:  int8(42),
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "42"),
 		}, &sql.ColumnOrder{AfterColumn: "baz"},
 	),
 	`ALTER TABLE foo ADD COLUMN bar INT NOT NULL DEFAULT -42.0 COMMENT 'hello' AFTER baz`: plan.NewAddColumn(
@@ -565,7 +565,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.Int32,
 			Nullable: false,
 			Comment:  "hello",
-			Default:  float64(-42.0),
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "-42.0"),
 		}, &sql.ColumnOrder{AfterColumn: "baz"},
 	),
 	`ALTER TABLE foo ADD COLUMN bar INT NOT NULL DEFAULT (2+2)/2 COMMENT 'hello' AFTER baz`: plan.NewAddColumn(
@@ -574,7 +574,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.Int32,
 			Nullable: false,
 			Comment:  "hello",
-			Default:  int64(2),
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "(2+2)/2"),
 		}, &sql.ColumnOrder{AfterColumn: "baz"},
 	),
 	`ALTER TABLE foo ADD COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello'`: plan.NewAddColumn(
@@ -583,7 +583,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Default),
 			Nullable: true,
 			Comment:  "hello",
-			Default:  "string",
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`),
 		}, nil,
 	),
 	`ALTER TABLE foo ADD COLUMN bar FLOAT NULL DEFAULT 32.0 COMMENT 'hello'`: plan.NewAddColumn(
@@ -592,7 +592,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.Float32,
 			Nullable: true,
 			Comment:  "hello",
-			Default:  float64(32.0),
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "32.0"),
 		}, nil,
 	),
 	`ALTER TABLE foo ADD COLUMN bar INT DEFAULT 1 FIRST`: plan.NewAddColumn(
@@ -600,7 +600,7 @@ var fixtures = map[string]sql.Node{
 			Name:     "bar",
 			Type:     sql.Int32,
 			Nullable: true,
-			Default:  int8(1),
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1"),
 		}, &sql.ColumnOrder{First: true},
 	),
 	`ALTER TABLE foo ADD INDEX (v1)`: plan.NewAlterCreateIndex(
@@ -620,7 +620,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Default),
 			Nullable: true,
 			Comment:  "hello",
-			Default:  "string",
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`),
 		}, &sql.ColumnOrder{First: true},
 	),
 	`ALTER TABLE foo CHANGE COLUMN bar baz VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`: plan.NewModifyColumn(
@@ -629,7 +629,7 @@ var fixtures = map[string]sql.Node{
 			Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Default),
 			Nullable: true,
 			Comment:  "hello",
-			Default:  "string",
+			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`),
 		}, &sql.ColumnOrder{First: true},
 	),
 	`ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b)`: plan.NewAlterAddForeignKey(

--- a/sql/parse/parsecolumndefault_test.go
+++ b/sql/parse/parsecolumndefault_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"github.com/liquidata-inc/go-mysql-server/sql"
+	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	"github.com/liquidata-inc/go-mysql-server/sql/expression/function"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func TestStringToColumnDefaultValue(t *testing.T) {
+	tests := []struct{
+		exprStr string
+		expectedExpr sql.Expression
+	}{
+		{ //TODO: expand tests, more types
+			"2",
+			sql.NewColumnDefaultValue(
+				expression.NewLiteral(int8(2), sql.Int8),
+				true,
+			),
+		},
+		{
+			"(2)",
+			sql.NewColumnDefaultValue(
+				expression.NewLiteral(int8(2), sql.Int8),
+				false,
+			),
+		},
+		{
+			"(RAND() + 5)",
+			sql.NewColumnDefaultValue(
+				expression.NewArithmetic(
+					must(function.NewRand),
+					expression.NewLiteral(int8(5), sql.Int8),
+					"+",
+				),
+				false,
+			),
+		},
+		{
+			"(GREATEST(RAND(), RAND()))",
+			sql.NewColumnDefaultValue(
+				must(function.NewGreatest,
+					must(function.NewRand),
+					must(function.NewRand),
+				),
+				false,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.exprStr, func(t *testing.T) {
+			res, err := StringToColumnDefaultValue(sql.NewEmptyContext(), test.exprStr)
+			if test.expectedExpr == nil {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedExpr, res)
+			}
+		})
+	}
+}
+
+// must executes functions of the form "func(args...) (sql.Expression, error)" and panics on errors
+func must(f interface{}, args ...interface{}) sql.Expression {
+	fType := reflect.TypeOf(f)
+	if fType.Kind() != reflect.Func ||
+		fType.NumOut() != 2 ||
+		!fType.Out(0).AssignableTo(reflect.TypeOf((*sql.Expression)(nil)).Elem()) ||
+		!fType.Out(1).AssignableTo(reflect.TypeOf((*error)(nil)).Elem()) {
+		panic("invalid function given")
+	}
+	// we let reflection ensure that the arguments match
+	argVals := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		argVals[i] = reflect.ValueOf(arg)
+	}
+	fVal := reflect.ValueOf(f)
+	out := fVal.Call(argVals)
+	err, _ := out[1].Interface().(error)
+	if err != nil {
+		panic("must err is nil")
+	}
+	return out[0].Interface().(sql.Expression)
+}
+

--- a/sql/plan/create_index_test.go
+++ b/sql/plan/create_index_test.go
@@ -1,4 +1,4 @@
-package plan
+package plan_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"github.com/liquidata-inc/go-mysql-server/memory"
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	. "github.com/liquidata-inc/go-mysql-server/sql/plan"
 	"github.com/liquidata-inc/go-mysql-server/test"
 
 	"github.com/stretchr/testify/require"
@@ -294,19 +295,14 @@ func TestCreateIndexWithIter(t *testing.T) {
 	ci.Catalog = catalog
 	ci.CurrentDatabase = "foo"
 
-	columns, exprs, err := getColumnsAndPrepareExpressions(ci.Exprs)
+	columns, exprs, err := GetColumnsAndPrepareExpressions(ci.Exprs)
 	require.NoError(err)
 
 	ctx := sql.NewContext(context.Background(), sql.WithIndexRegistry(idxReg))
 	iter, err := foo.IndexKeyValues(ctx, columns)
 	require.NoError(err)
 
-	iter = &evalPartitionKeyValueIter{
-		ctx:     ctx,
-		columns: columns,
-		exprs:   exprs,
-		iter:    iter,
-	}
+	iter = NewEvalPartitionKeyValueIter(ctx, iter, columns, exprs)
 
 	var (
 		vals [][]interface{}

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -339,13 +339,14 @@ func (a *AddColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) 
 		return nil, ErrNullDefault.New()
 	}
 
-	var defaultVal interface{}
+	//TODO: verify that the returned expression can be implicitly coerced into the target type
+	//var defaultVal interface{}
 	if a.column.Default != nil {
-		defaultVal, err = a.column.Type.Convert(a.column.Default)
-		if err != nil {
-			return nil, ErrIncompatibleDefaultType.New()
-		}
-		a.column.Default = defaultVal
+		//defaultVal, err = a.column.Type.Convert(a.column.Default)
+		//if err != nil {
+		//	return nil, ErrIncompatibleDefaultType.New()
+		//}
+		//a.column.Default = defaultVal
 	}
 
 	return sql.RowsToRowIter(), alterable.AddColumn(ctx, a.column, a.order)
@@ -511,13 +512,14 @@ func (m *ModifyColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, erro
 		}
 	}
 
+	//TODO: verify that the returned expression can be implicitly coerced into the target type
 	if m.column.Default != nil {
-		var defaultVal interface{}
-		defaultVal, err = m.column.Type.Convert(m.column.Default)
-		if err != nil {
-			return nil, ErrIncompatibleDefaultType.New()
-		}
-		m.column.Default = defaultVal
+		//var defaultVal interface{}
+		//defaultVal, err = m.column.Type.Convert(m.column.Default)
+		//if err != nil {
+		//	return nil, ErrIncompatibleDefaultType.New()
+		//}
+		//m.column.Default = defaultVal
 	}
 
 	return sql.RowsToRowIter(), alterable.ModifyColumn(ctx, m.columnName, m.column, m.order)

--- a/sql/plan/drop_index_test.go
+++ b/sql/plan/drop_index_test.go
@@ -1,4 +1,4 @@
-package plan
+package plan_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"github.com/liquidata-inc/go-mysql-server/memory"
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	. "github.com/liquidata-inc/go-mysql-server/sql/plan"
 )
 
 func TestDeleteIndex(t *testing.T) {

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -115,7 +115,7 @@ func (p *InsertInto) Execute(ctx *sql.Context) (int, error) {
 			if !f.Nullable && f.Default == nil {
 				return 0, ErrInsertIntoNonNullableDefaultNullColumn.New(f.Name)
 			}
-			projExprs[i] = expression.NewLiteral(f.Default, f.Type)
+			projExprs[i] = f.Default
 		}
 	}
 

--- a/sql/plan/resolved_table_test.go
+++ b/sql/plan/resolved_table_test.go
@@ -1,4 +1,4 @@
-package plan
+package plan_test
 
 import (
 	"context"
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/liquidata-inc/go-mysql-server/sql"
+	"github.com/liquidata-inc/go-mysql-server/sql/parse"
+	. "github.com/liquidata-inc/go-mysql-server/sql/plan"
 )
 
 func TestResolvedTable(t *testing.T) {
@@ -51,9 +53,9 @@ func TestResolvedTableCancelled(t *testing.T) {
 
 func newTableTest(source string) sql.Table {
 	schema := []*sql.Column{
-		{Name: "col1", Type: sql.Int32, Source: source, Default: int32(0), Nullable: false},
-		{Name: "col2", Type: sql.Int64, Source: source, Default: int64(0), Nullable: false},
-		{Name: "col3", Type: sql.Text, Source: source, Default: "", Nullable: false},
+		{Name: "col1", Type: sql.Int32, Source: source, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), "0"), Nullable: false},
+		{Name: "col2", Type: sql.Int64, Source: source, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), "0"), Nullable: false},
+		{Name: "col3", Type: sql.Text, Source: source, Default: parse.MustStringToColumnDefaultValue(sql.NewEmptyContext(), `""`), Nullable: false},
 	}
 
 	keys := [][]byte{

--- a/sql/plan/show_create_database.go
+++ b/sql/plan/show_create_database.go
@@ -53,8 +53,8 @@ func (s *ShowCreateDatabase) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter
 	buf.WriteRune('`')
 	buf.WriteString(fmt.Sprintf(
 		" /*!40100 DEFAULT CHARACTER SET %s COLLATE %s */",
-		sql.DefaultCharacterSet,
-		sql.DefaultCollation,
+		sql.Collation_Default.CharacterSet().String(),
+		sql.Collation_Default.String(),
 	))
 
 	return sql.RowsToRowIter(

--- a/sql/plan/show_create_database_test.go
+++ b/sql/plan/show_create_database_test.go
@@ -19,7 +19,7 @@ func TestShowCreateDatabase(t *testing.T) {
 	require.NoError(err)
 
 	require.Equal([]sql.Row{
-		{"foo", "CREATE DATABASE /*!32312 IF NOT EXISTS*/ `foo` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */"},
+		{"foo", "CREATE DATABASE /*!32312 IF NOT EXISTS*/ `foo` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */"},
 	}, rows)
 
 	node = NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false)
@@ -30,6 +30,6 @@ func TestShowCreateDatabase(t *testing.T) {
 	require.NoError(err)
 
 	require.Equal([]sql.Row{
-		{"foo", "CREATE DATABASE `foo` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8_bin */"},
+		{"foo", "CREATE DATABASE `foo` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */"},
 	}, rows)
 }

--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -155,15 +155,8 @@ func (i *showCreateTablesIter) produceCreateTableStatement(table sql.Table) (str
 			stmt = fmt.Sprintf("%s NOT NULL", stmt)
 		}
 
-		switch def := col.Default.(type) {
-		case string:
-			if def != "" {
-				stmt = fmt.Sprintf("%s DEFAULT %q", stmt, def)
-			}
-		default:
-			if def != nil {
-				stmt = fmt.Sprintf("%s DEFAULT %v", stmt, col.Default)
-			}
+		if col.Default != nil {
+			stmt = fmt.Sprintf("%s DEFAULT %s", stmt, col.Default.String())
 		}
 
 		if col.Comment != "" {
@@ -192,7 +185,7 @@ func (i *showCreateTablesIter) produceCreateTableStatement(table sql.Table) (str
 
 		var indexCols []string
 		for _, expr := range index.Expressions() {
-			col := getColumnFromIndexExpr(expr, table)
+			col := GetColumnFromIndexExpr(expr, table)
 			if col != nil {
 				indexCols = append(indexCols, fmt.Sprintf("`%s`", col.Name))
 			}
@@ -270,7 +263,7 @@ func isPrimaryKeyIndex(index sql.Index, table sql.Table) bool {
 	}
 
 	for _, expr := range index.Expressions() {
-		if col := getColumnFromIndexExpr(expr, table); col != nil {
+		if col := GetColumnFromIndexExpr(expr, table); col != nil {
 			found := false
 			for _, pk := range pks {
 				if col == pk {

--- a/sql/plan/show_create_table_test.go
+++ b/sql/plan/show_create_table_test.go
@@ -1,4 +1,4 @@
-package plan
+package plan_test
 
 import (
 	"testing"
@@ -9,24 +9,26 @@ import (
 	"github.com/liquidata-inc/go-mysql-server/memory"
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	"github.com/liquidata-inc/go-mysql-server/sql/parse"
+	. "github.com/liquidata-inc/go-mysql-server/sql/plan"
 )
 
 func TestShowCreateTable(t *testing.T) {
 	var require = require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	db := memory.NewDatabase("testdb")
 
 	table := memory.NewTable(
 		"test-table",
 		sql.Schema{
-			&sql.Column{Name: "baz", Type: sql.Text, Default: "", Nullable: false, PrimaryKey: true},
-			&sql.Column{Name: "zab", Type: sql.Int32, Default: int32(0), Nullable: true, PrimaryKey: true},
-			&sql.Column{Name: "bza", Type: sql.Uint64, Default: uint64(0), Nullable: true, Comment: "hello"},
-			&sql.Column{Name: "foo", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 123), Default: "", Nullable: true},
-			&sql.Column{Name: "pok", Type: sql.MustCreateStringWithDefaults(sqltypes.Char, 123), Default: "", Nullable: true},
+			&sql.Column{Name: "baz", Type: sql.Text, Default: nil, Nullable: false, PrimaryKey: true},
+			&sql.Column{Name: "zab", Type: sql.Int32, Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true, PrimaryKey: true},
+			&sql.Column{Name: "bza", Type: sql.Uint64, Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true, Comment: "hello"},
+			&sql.Column{Name: "foo", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 123), Default: nil, Nullable: true},
+			&sql.Column{Name: "pok", Type: sql.MustCreateStringWithDefaults(sqltypes.Char, 123), Default: nil, Nullable: true},
 		})
 
-	ctx := sql.NewEmptyContext()
 	db.AddTable(table.Name(), table)
 
 	cat := sql.NewCatalog()
@@ -65,20 +67,20 @@ func TestShowCreateTable(t *testing.T) {
 
 func TestShowCreateTableWithIndexAndForeignKeys(t *testing.T) {
 	var require = require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	db := memory.NewDatabase("testdb")
 
 	table := memory.NewTable(
 		"test-table",
 		sql.Schema{
-			&sql.Column{Name: "baz", Source: "test-table", Type: sql.Text, Default: "", Nullable: false, PrimaryKey: true},
-			&sql.Column{Name: "zab", Source: "test-table", Type: sql.Int32, Default: int32(0), Nullable: true, PrimaryKey: true},
-			&sql.Column{Name: "bza", Source: "test-table", Type: sql.Uint64, Default: uint64(0), Nullable: true, Comment: "hello"},
-			&sql.Column{Name: "foo", Source: "test-table", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 123), Default: "", Nullable: true},
-			&sql.Column{Name: "pok", Source: "test-table", Type: sql.MustCreateStringWithDefaults(sqltypes.Char, 123), Default: "", Nullable: true},
+			&sql.Column{Name: "baz", Source: "test-table", Type: sql.Text, Default: nil, Nullable: false, PrimaryKey: true},
+			&sql.Column{Name: "zab", Source: "test-table", Type: sql.Int32, Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true, PrimaryKey: true},
+			&sql.Column{Name: "bza", Source: "test-table", Type: sql.Uint64, Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true, Comment: "hello"},
+			&sql.Column{Name: "foo", Source: "test-table", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 123), Default: nil, Nullable: true},
+			&sql.Column{Name: "pok", Source: "test-table", Type: sql.MustCreateStringWithDefaults(sqltypes.Char, 123), Default: nil, Nullable: true},
 		})
 
-	ctx := sql.NewEmptyContext()
 	require.NoError(table.CreateForeignKey(ctx, "fk1", []string{"baz", "zab"}, "otherTable", []string{"a", "b"}, sql.ForeignKeyReferenceOption_DefaultAction, sql.ForeignKeyReferenceOption_Cascade))
 	require.NoError(table.CreateForeignKey(ctx, "fk2", []string{"foo"}, "otherTable", []string{"b"}, sql.ForeignKeyReferenceOption_Restrict, sql.ForeignKeyReferenceOption_DefaultAction))
 	require.NoError(table.CreateForeignKey(ctx, "fk3", []string{"bza"}, "otherTable", []string{"c"}, sql.ForeignKeyReferenceOption_DefaultAction, sql.ForeignKeyReferenceOption_DefaultAction))
@@ -138,17 +140,18 @@ func TestShowCreateTableWithIndexAndForeignKeys(t *testing.T) {
 
 func TestShowCreateView(t *testing.T) {
 	var require = require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	db := memory.NewDatabase("testdb")
 
 	table := memory.NewTable(
 		"test-table",
 		sql.Schema{
-			&sql.Column{Name: "baz", Type: sql.Text, Default: "", Nullable: false, PrimaryKey: true},
-			&sql.Column{Name: "zab", Type: sql.Int32, Default: int32(0), Nullable: true, PrimaryKey: true},
-			&sql.Column{Name: "bza", Type: sql.Uint64, Default: uint64(0), Nullable: true, Comment: "hello"},
-			&sql.Column{Name: "foo", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 123), Default: "", Nullable: true},
-			&sql.Column{Name: "pok", Type: sql.MustCreateStringWithDefaults(sqltypes.Char, 123), Default: "", Nullable: true},
+			&sql.Column{Name: "baz", Type: sql.Text, Default: nil, Nullable: false, PrimaryKey: true},
+			&sql.Column{Name: "zab", Type: sql.Int32, Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true, PrimaryKey: true},
+			&sql.Column{Name: "bza", Type: sql.Uint64, Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true, Comment: "hello"},
+			&sql.Column{Name: "foo", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 123), Default: nil, Nullable: true},
+			&sql.Column{Name: "pok", Type: sql.MustCreateStringWithDefaults(sqltypes.Char, 123), Default: nil, Nullable: true},
 		})
 
 	db.AddTable(table.Name(), table)
@@ -161,7 +164,6 @@ func TestShowCreateView(t *testing.T) {
 		true,
 	)
 
-	ctx := sql.NewEmptyContext()
 	rowIter, _ := showCreateTable.RowIter(ctx, nil)
 
 	row, err := rowIter.Next()

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -101,7 +101,7 @@ func (i *showIndexesIter) Next() (sql.Row, error) {
 	}
 
 	nullable := ""
-	if col := getColumnFromIndexExpr(show.expression, tbl); col != nil {
+	if col := GetColumnFromIndexExpr(show.expression, tbl); col != nil {
 		columnName, expression = col.Name, nil
 		if col.Nullable {
 			nullable = "YES"
@@ -139,9 +139,9 @@ func (i *showIndexesIter) Next() (sql.Row, error) {
 	), nil
 }
 
-// getColumnFromIndexExpr returns column from the table given using the expression string given, in the form
+// GetColumnFromIndexExpr returns column from the table given using the expression string given, in the form
 // "table.column". Returns nil if the expression doesn't represent a column.
-func getColumnFromIndexExpr(expr string, table sql.Table) *sql.Column {
+func GetColumnFromIndexExpr(expr string, table sql.Table) *sql.Column {
 	for _, col := range table.Schema() {
 		if col.Source+"."+col.Name == expr {
 			return col

--- a/sql/plan/show_indexes_test.go
+++ b/sql/plan/show_indexes_test.go
@@ -1,4 +1,4 @@
-package plan
+package plan_test
 
 import (
 	"testing"
@@ -9,9 +9,12 @@ import (
 	"github.com/liquidata-inc/go-mysql-server/memory"
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	"github.com/liquidata-inc/go-mysql-server/sql/parse"
+	. "github.com/liquidata-inc/go-mysql-server/sql/plan"
 )
 
 func TestShowIndexes(t *testing.T) {
+	ctx := sql.NewEmptyContext()
 	unresolved := NewShowIndexes(NewUnresolvedTable("table-test", ""))
 	require.False(t, unresolved.Resolved())
 	require.Equal(t, []sql.Node{NewUnresolvedTable("table-test", "")}, unresolved.Children())
@@ -28,7 +31,7 @@ func TestShowIndexes(t *testing.T) {
 			table: memory.NewTable(
 				"test1",
 				sql.Schema{
-					&sql.Column{Name: "foo", Type: sql.Int32, Source: "test1", Default: int32(0), Nullable: false},
+					&sql.Column{Name: "foo", Type: sql.Int32, Source: "test1", Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: false},
 				},
 			),
 		},
@@ -37,8 +40,8 @@ func TestShowIndexes(t *testing.T) {
 			table: memory.NewTable(
 				"test2",
 				sql.Schema{
-					&sql.Column{Name: "bar", Type: sql.Int64, Source: "test2", Default: int64(0), Nullable: true},
-					&sql.Column{Name: "rab", Type: sql.Int64, Source: "test2", Default: int32(0), Nullable: false},
+					&sql.Column{Name: "bar", Type: sql.Int64, Source: "test2", Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true},
+					&sql.Column{Name: "rab", Type: sql.Int64, Source: "test2", Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: false},
 				},
 			),
 		},
@@ -47,9 +50,9 @@ func TestShowIndexes(t *testing.T) {
 			table: memory.NewTable(
 				"test3",
 				sql.Schema{
-					&sql.Column{Name: "baz", Type: sql.Text, Source: "test3", Default: "", Nullable: false},
-					&sql.Column{Name: "zab", Type: sql.Int32, Source: "test3", Default: int32(0), Nullable: true},
-					&sql.Column{Name: "bza", Type: sql.Int64, Source: "test3", Default: int64(0), Nullable: true},
+					&sql.Column{Name: "baz", Type: sql.Text, Source: "test3", Default: parse.MustStringToColumnDefaultValue(ctx, `""`), Nullable: false},
+					&sql.Column{Name: "zab", Type: sql.Int32, Source: "test3", Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true},
+					&sql.Column{Name: "bza", Type: sql.Int64, Source: "test3", Default: parse.MustStringToColumnDefaultValue(ctx, "0"), Nullable: true},
 				},
 			),
 		},
@@ -58,7 +61,7 @@ func TestShowIndexes(t *testing.T) {
 			table: memory.NewTable(
 				"test4",
 				sql.Schema{
-					&sql.Column{Name: "oof", Type: sql.Text, Source: "test4", Default: "", Nullable: false},
+					&sql.Column{Name: "oof", Type: sql.Text, Source: "test4", Default: parse.MustStringToColumnDefaultValue(ctx, `""`), Nullable: false},
 				},
 			),
 		},
@@ -92,7 +95,6 @@ func TestShowIndexes(t *testing.T) {
 			showIdxs := NewShowIndexes(NewResolvedTable(test.table))
 			showIdxs.(*ShowIndexes).IndexesToShow = []sql.Index{idx}
 
-			ctx := sql.NewEmptyContext()
 			rowIter, err := showIdxs.RowIter(ctx, nil)
 			assert.NoError(t, err)
 
@@ -104,7 +106,7 @@ func TestShowIndexes(t *testing.T) {
 				var nullable string
 				var columnName, ex interface{}
 				columnName, ex = "NULL", expressions[i].String()
-				if col := getColumnFromIndexExpr(ex.(string), test.table); col != nil {
+				if col := GetColumnFromIndexExpr(ex.(string), test.table); col != nil {
 					columnName, ex = col.Name, nil
 					if col.Nullable {
 						nullable = "YES"

--- a/sql/plan/showcolumns.go
+++ b/sql/plan/showcolumns.go
@@ -62,7 +62,7 @@ func (s *ShowColumns) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error
 		var row sql.Row
 		var collation interface{}
 		if sql.IsTextOnly(col.Type) {
-			collation = sql.DefaultCollation
+			collation = sql.Collation_Default.String()
 		}
 
 		var null = "NO"
@@ -88,7 +88,7 @@ func (s *ShowColumns) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error
 
 		var defaultVal string
 		if col.Default != nil {
-			defaultVal = fmt.Sprint(col.Default)
+			defaultVal = col.Default.String()
 		}
 
 		// TODO: rather than lower-casing here, we should lower-case the String() method of types
@@ -149,7 +149,7 @@ func (s *ShowColumns) isFirstColInUniqueKey(col *sql.Column, table sql.Table) bo
 			continue
 		}
 
-		firstIndexCol := getColumnFromIndexExpr(idx.Expressions()[0], table)
+		firstIndexCol := GetColumnFromIndexExpr(idx.Expressions()[0], table)
 		if firstIndexCol != nil && firstIndexCol.Name == col.Name {
 			return true
 		}
@@ -164,7 +164,7 @@ func (s *ShowColumns) isFirstColInNonUniqueKey(col *sql.Column, table sql.Table)
 			continue
 		}
 
-		firstIndexCol := getColumnFromIndexExpr(idx.Expressions()[0], table)
+		firstIndexCol := GetColumnFromIndexExpr(idx.Expressions()[0], table)
 		if firstIndexCol != nil && firstIndexCol.Name == col.Name {
 			return true
 		}

--- a/sql/plan/showcolumns_test.go
+++ b/sql/plan/showcolumns_test.go
@@ -1,4 +1,4 @@
-package plan
+package plan_test
 
 import (
 	"testing"
@@ -8,18 +8,21 @@ import (
 	"github.com/liquidata-inc/go-mysql-server/memory"
 	"github.com/liquidata-inc/go-mysql-server/sql"
 	"github.com/liquidata-inc/go-mysql-server/sql/expression"
+	"github.com/liquidata-inc/go-mysql-server/sql/parse"
+	. "github.com/liquidata-inc/go-mysql-server/sql/plan"
 )
 
 func TestShowColumns(t *testing.T) {
 	require := require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	table := NewResolvedTable(memory.NewTable("foo", sql.Schema{
 		{Name: "a", Source: "foo", Type: sql.Text, PrimaryKey: true},
 		{Name: "b", Source: "foo", Type: sql.Int64, Nullable: true},
-		{Name: "c", Source: "foo", Type: sql.Int64, Default: int64(1)},
+		{Name: "c", Source: "foo", Type: sql.Int64, Default: parse.MustStringToColumnDefaultValue(ctx, "1")},
 	}))
 
-	iter, err := NewShowColumns(false, table).RowIter(sql.NewEmptyContext(), nil)
+	iter, err := NewShowColumns(false, table).RowIter(ctx, nil)
 	require.NoError(err)
 
 	rows, err := sql.RowIterToRows(iter)
@@ -36,13 +39,14 @@ func TestShowColumns(t *testing.T) {
 
 func TestShowColumnsWithIndexes(t *testing.T) {
 	require := require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	table := NewResolvedTable(memory.NewTable("foo", sql.Schema{
 		{Name: "a", Source: "foo", Type: sql.Text, PrimaryKey: true},
 		{Name: "b", Source: "foo", Type: sql.Int64, Nullable: true},
-		{Name: "c", Source: "foo", Type: sql.Int64, Default: int64(1)},
+		{Name: "c", Source: "foo", Type: sql.Int64, Default: parse.MustStringToColumnDefaultValue(ctx, "1")},
 		{Name: "d", Source: "foo", Type: sql.Int64, Nullable: true},
-		{Name: "e", Source: "foo", Type: sql.Int64, Default: int64(1)},
+		{Name: "e", Source: "foo", Type: sql.Int64, Default: parse.MustStringToColumnDefaultValue(ctx, "1")},
 	}))
 
 	showColumns := NewShowColumns(false, table)
@@ -71,7 +75,7 @@ func TestShowColumnsWithIndexes(t *testing.T) {
 		},
 	}
 
-	iter, err := showColumns.RowIter(sql.NewEmptyContext(), nil)
+	iter, err := showColumns.RowIter(ctx, nil)
 	require.NoError(err)
 
 	rows, err := sql.RowIterToRows(iter)
@@ -122,21 +126,22 @@ func TestShowColumnsWithIndexes(t *testing.T) {
 
 func TestShowColumnsFull(t *testing.T) {
 	require := require.New(t)
+	ctx := sql.NewEmptyContext()
 
 	table := NewResolvedTable(memory.NewTable("foo", sql.Schema{
 		{Name: "a", Type: sql.Text, PrimaryKey: true},
 		{Name: "b", Type: sql.Int64, Nullable: true},
-		{Name: "c", Type: sql.Int64, Default: int64(1), Comment: "a comment"},
+		{Name: "c", Type: sql.Int64, Default: parse.MustStringToColumnDefaultValue(ctx, "1"), Comment: "a comment"},
 	}))
 
-	iter, err := NewShowColumns(true, table).RowIter(sql.NewEmptyContext(), nil)
+	iter, err := NewShowColumns(true, table).RowIter(ctx, nil)
 	require.NoError(err)
 
 	rows, err := sql.RowIterToRows(iter)
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{"a", "text", "utf8_bin", "NO", "PRI", "", "", "", ""},
+		{"a", "text", "utf8mb4_0900_ai_ci", "NO", "PRI", "", "", "", ""},
 		{"b", "bigint", nil, "YES", "", "", "", "", ""},
 		{"c", "bigint", nil, "NO", "", "1", "", "", "a comment"},
 	}

--- a/sql/plan/showtablestatus.go
+++ b/sql/plan/showtablestatus.go
@@ -116,20 +116,20 @@ func tableToStatusRow(table string) sql.Row {
 		// This column is unused. With the removal of .frm files in MySQL 8.0, this
 		// column now reports a hardcoded value of 10, which is the last .frm file
 		// version used in MySQL 5.7.
-		"10",       // Version
-		"Fixed",    // Row_format
-		int64(0),   // Rows
-		int64(0),   // Avg_row_length
-		int64(0),   // Data_length
-		int64(0),   // Max_data_length
-		int64(0),   // Index_length
-		int64(0),   // Data_free
-		int64(0),   // Auto_increment
-		nil,        // Create_time
-		nil,        // Update_time
-		nil,        // Check_time
-		"utf8_bin", // Collation
-		nil,        // Create_options
-		nil,        // Comments
+		"10",                           // Version
+		"Fixed",                        // Row_format
+		int64(0),                       // Rows
+		int64(0),                       // Avg_row_length
+		int64(0),                       // Data_length
+		int64(0),                       // Max_data_length
+		int64(0),                       // Index_length
+		int64(0),                       // Data_free
+		int64(0),                       // Auto_increment
+		nil,                            // Create_time
+		nil,                            // Update_time
+		nil,                            // Check_time
+		sql.Collation_Default.String(), // Collation
+		nil,                            // Create_options
+		nil,                            // Comments
 	)
 }

--- a/sql/plan/showtablestatus_test.go
+++ b/sql/plan/showtablestatus_test.go
@@ -35,8 +35,8 @@ func TestShowTableStatus(t *testing.T) {
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{"t1", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-		{"t2", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+		{"t1", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, sql.Collation_Default.String(), nil, nil},
+		{"t2", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, sql.Collation_Default.String(), nil, nil},
 	}
 
 	require.Equal(expected, rows)
@@ -51,8 +51,8 @@ func TestShowTableStatus(t *testing.T) {
 	require.NoError(err)
 
 	expected = []sql.Row{
-		{"t1", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
-		{"t2", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8_bin", nil, nil},
+		{"t1", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, sql.Collation_Default.String(), nil, nil},
+		{"t2", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, sql.Collation_Default.String(), nil, nil},
 	}
 
 	require.Equal(expected, rows)

--- a/sql/session.go
+++ b/sql/session.go
@@ -242,7 +242,7 @@ func DefaultSessionConfig() map[string]TypedValue {
 		"max_allowed_packet":       TypedValue{Int32, math.MaxInt32},
 		"sql_mode":                 TypedValue{LongText, ""},
 		"gtid_mode":                TypedValue{Int32, int32(0)},
-		"collation_database":       TypedValue{LongText, "utf8_bin"},
+		"collation_database":       TypedValue{LongText, Collation_Default.String()},
 		"ndbinfo_version":          TypedValue{LongText, ""},
 		"sql_select_limit":         TypedValue{Int32, math.MaxInt32},
 		"transaction_isolation":    TypedValue{LongText, "READ UNCOMMITTED"},


### PR DESCRIPTION
The most rough draft thing ever. This PR seems FAR larger than it actually is. `information_schema.go` and `parse_test.go` make up like 4500 lines of change, but I just put those large maps inside of a function, which tabbed all of the lines over by one, but results in a massive diff.

I ran into a ton of import cycles while trying to make this all work. This PR does not have any cycles, but it's far from an elegant solution. I feel the true solution is to compartmentalize the `sql` package (and probably other packages while we're at it), but that would be a **ton** of work for integrators (and probably this project too, idk how good the refactoring tools are for moving between packages). So this is what I've got in the meantime.

The overall flow with this implementation would be for an integrator to store the expression string that's returned from `CREATE/ALTER TABLE`, which can be fetched by just calling `String()` on the returned expression. When an integrator is loading their table's schemas into the engine, they'd call `sql.StringToColumnDefaultValue`, which would give them the expression back. In the event that an integrator only wants to grab a default value, then they don't have to instantiate the entire engine, and can just call the aforementioned function and call `Eval()` on the expression.

I'm also considering moving the parsing code out of the `parse` package and into the default functions, which would be duplicating quite a bit of code (specifically `exprToExpression`), but would remove the testing dependency on the `parse` package.