### PR TITLE
Don't set default max connections to 1

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -60,8 +60,8 @@ func NewServer(cfg Config, e *sqle.Engine, sb SessionBuilder) (*Server, error) {
 		cfg.ConnWriteTimeout = 0
 	}
 
-	if cfg.MaxConnections == 0 {
-		cfg.MaxConnections = 1
+	if cfg.MaxConnections < 0 {
+		cfg.MaxConnections = 0
 	}
 
 	handler := NewHandler(e,


### PR DESCRIPTION
Signed-off-by: Zach Musgrave <zach@liquidata.co>