### PR TITLE
added support for ON DUPLICATE KEY UPDATE

### DIFF
--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -233,6 +233,18 @@ var InsertQueries = []WriteQueryTest{
 			{int64(14), "third row new"},
 		},
 	},
+	{
+		"INSERT INTO mytable (i,s) values (1, 'hello') ON DUPLICATE KEY UPDATE s='hello'",
+		[]sql.Row{{sql.NewOkResult(2)}},
+		"SELECT * FROM mytable WHERE i = 1",
+		[]sql.Row{{int64(1), "hello"}},
+	},
+	{
+		"INSERT INTO mytable (i,s) values (10, 'hello') ON DUPLICATE KEY UPDATE s='hello'",
+		[]sql.Row{{sql.NewOkResult(1)}},
+		"SELECT * FROM mytable WHERE i = 10",
+		[]sql.Row{{int64(10), "hello"}},
+	},
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -844,8 +844,9 @@ func convertDropView(ctx *sql.Context, c *sqlparser.DDL) (sql.Node, error) {
 }
 
 func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
-	if len(i.OnDup) > 0 {
-		return nil, ErrUnsupportedFeature.New("ON DUPLICATE KEY")
+	onDupExprs, err := updateExprsToExpressions(ctx, sqlparser.UpdateExprs(i.OnDup))
+	if err != nil {
+		return nil, err
 	}
 
 	if len(i.Ignore) > 0 {
@@ -864,6 +865,7 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 		src,
 		isReplace,
 		columnsToStrings(i.Columns),
+		onDupExprs,
 	), nil
 }
 

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1010,6 +1010,7 @@ var fixtures = map[string]sql.Node{
 		}}),
 		false,
 		[]string{"col1", "col2"},
+		[]sql.Expression{},
 	),
 	`REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`: plan.NewInsertInto(
 		plan.NewUnresolvedTable("t1", ""),
@@ -1019,6 +1020,7 @@ var fixtures = map[string]sql.Node{
 		}}),
 		true,
 		[]string{"col1", "col2"},
+		[]sql.Expression{},
 	),
 	`SHOW TABLES`:                           plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
 	`SHOW FULL TABLES`:                      plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
@@ -2151,6 +2153,7 @@ var fixtures = map[string]sql.Node{
 					),
 					false,
 					[]string{"a", "b"},
+					[]sql.Expression{},
 				),
 			},
 		), "",


### PR DESCRIPTION
Added support for ON DUPLICATE KEY UPDATE for INSERT statements.

Example:
```
INSERT INTO mytable (i,s) values (1, 'hello') ON DUPLICATE KEY UPDATE s='hello'
```

Tested with: `go test -run TestInsertInto`
